### PR TITLE
Improve circleci caching

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,12 +15,12 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - node-deps-v1-{{ .Branch }}-{{checksum "package-lock.json"}}
+            - node-deps-v1-{{ checksum "package.json" }}-{{checksum "package-lock.json"}}
       - run:
           name: Install packages
-          command: npm ci
+          command: "[ ! -d node_modules ] && npm ci --loglevel warn --yes || echo using cache -- checksum match [package.json, package-lock.json]"
       - save_cache:
-          key: node-deps-v1-{{ .Branch }}-{{checksum "package-lock.json"}}
+          key: node-deps-v1-{{ checksum "package.json" }}-{{checksum "package-lock.json"}}
           paths:
             - ~/.npm
             - ./node_modules


### PR DESCRIPTION
Subtle tweak but significant when we start writing more tests

- Cache key doesn't depend on branch, just pure checksum on package/lock.json
- Skip `npm ci` altogether if cache matches

Speedup is around 2x for a cached workflow
