### PR TITLE
Add text box component

### DIFF
--- a/src/app.scss
+++ b/src/app.scss
@@ -10,7 +10,10 @@
   flex-direction: column;
   justify-content: space-evenly;
   align-items: center;
-  height: 100vh;
+  gap: 32px;
+  min-height: 100vh;
+  height: 100%;
+  padding: 16px;
 
   .text-areas {
     display: flex;
@@ -20,7 +23,7 @@
     padding: 16px;
     width: 800px;
   }
-  
+
   .text-box {
     width: 400px;
     padding: 16px;

--- a/src/app.scss
+++ b/src/app.scss
@@ -20,6 +20,18 @@
     padding: 16px;
     width: 800px;
   }
+  
+  .text-box {
+    width: 400px;
+    padding: 16px;
+    background-color: white;
+  }
+
+  .text-box-dark {
+    width: 400px;
+    padding: 16px;
+    background-color: $black;
+  }
 
   .search-bar {
     display: flex;

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -7,6 +7,7 @@ import { Deck } from './models/deck';
 import { SearchBar } from './components/search-bar/search-bar';
 import { DropDown, DropDownOption } from './components/drop-down/drop-down';
 import { TextArea } from './components/text-area/text-area';
+import { TextBox } from './components/text-box/text-box';
 
 const testDeck: Deck = {
   id: 0,
@@ -41,6 +42,12 @@ function App() {
           value="what is a gerund; what is a gerund; what is a gerund; what is a gerund;"
           readonly={true}
         />
+      </div>
+      <div className="text-box">
+        <TextBox label="username" onChange={() => console.log('changed')} />
+      </div>
+      <div className="text-box-dark">
+        <TextBox label="username" variant="dark" onChange={() => console.log('changed')} />
       </div>
       <div className="search-bar">
         <SearchBar

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -26,6 +26,9 @@ function App() {
   // (e.g.) read from textAreaContent when user submits a form
   const [textAreaContent, setTextAreaContent] = useState('');
 
+  const [textBoxValue1, setTextBoxValue1] = useState('');
+  const [textBoxValue2, setTextBoxValue2] = useState('');
+
   return (
     <div className="App">
       <div className="text-areas">
@@ -44,10 +47,19 @@ function App() {
         />
       </div>
       <div className="text-box">
-        <TextBox label="username" onChange={() => console.log('changed')} />
+        <TextBox
+          label="username"
+          value={textBoxValue1}
+          onChange={(v: string) => setTextBoxValue1(v)}
+        />
       </div>
       <div className="text-box-dark">
-        <TextBox label="username" variant="dark" onChange={() => console.log('changed')} />
+        <TextBox
+          label="username"
+          variant="dark"
+          value={textBoxValue2}
+          onChange={(v: string) => setTextBoxValue2(v)}
+        />
       </div>
       <div className="search-bar">
         <SearchBar

--- a/src/assets/_colors.scss
+++ b/src/assets/_colors.scss
@@ -2,6 +2,7 @@ $black: #1d1d21;
 $light-blue: #8b92c0;
 $electric-blue: #4a57b5;
 $grey: #989baa;
+$dark-grey: #63656e;
 $deck-cover-white: #efefef;
 $deck-cover-blue: #3e4154;
 $flashcard-white: #cfd2e3;

--- a/src/components/text-box/text-box.scss
+++ b/src/components/text-box/text-box.scss
@@ -1,0 +1,66 @@
+@import url('https://fonts.googleapis.com/css2?family=Comfortaa:wght@300;700&display=swap');
+@import '../../assets/colors';
+@import '../../assets/styles';
+
+// component is light-theme by default
+$gap: 4px;
+$label-font-size: 14px;
+$label-legend-font-size: 12px;
+
+.c-text-box-wrapper {
+    display: flex;
+    flex-direction: column;
+    gap: $gap;
+    box-sizing: border-box;
+    width: 100%;
+
+    &.dark {
+        background-color: $black;
+    }
+}
+
+.c-text-box-label {
+    width: fit-content;
+    min-height: $label-font-size;
+    padding: 0px 2px;
+    font-size: $label-font-size;
+    background-color: $white;
+    color: $grey;
+    transition: transform 100ms ease-in-out;
+
+    &.as-legend {
+        font-size: $label-legend-font-size;
+        padding: 0px 4px;
+        transform: translate(16px, $label-font-size - 2px);
+    }
+
+    .dark & {
+        background-color: $black;
+        color: $light-blue;
+    }
+}
+
+.c-text-box-input {
+    font-family: "Comfortaa";
+    color: $blue;
+    border: 2px solid $grey; 
+    border-radius: $standard-radius;
+    box-sizing: border-box;
+    padding: 8px;
+    width: 100%;
+
+    &:focus, &:focus-visible {
+        outline: none;
+        border: 2px solid $dark-grey;
+    }
+
+    .dark & {
+        color: $white;
+        background-color: $black;
+        border: 2px solid $light-blue;
+
+        &:focus, &:focus-visible {
+            outline: none;
+        }
+    }
+}

--- a/src/components/text-box/text-box.test.tsx
+++ b/src/components/text-box/text-box.test.tsx
@@ -1,10 +1,29 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { TextBox } from './text-box';
 
 const TEST_LABEL = 'TEST_LABEL';
 const TEST_PLACEHOLDER = 'TEST_PLACEHOLDER';
-const TEST_INITIAL_TEXT = 'TEST_INITIAL_TEXT';
+const TEST_VALUE = 'TEST_VALUE';
+
+// text box state is lifted, use this component to propagate changes
+interface MockParentProps {
+  value?: string;
+  label?: string;
+  placeholder?: string;
+}
+
+const MockParent = ({ value, label, placeholder }: MockParentProps) => {
+  const [val, setVal] = useState(value ?? '');
+  return (
+    <TextBox
+      value={val}
+      label={label}
+      placeholder={placeholder}
+      onChange={(v: string) => setVal(v)}
+    />
+  );
+};
 
 describe('TextBox', () => {
   it('should render correctly with default props', () => {
@@ -21,7 +40,7 @@ describe('TextBox', () => {
   });
 
   it('should render placeholder', () => {
-    const { container } = render(<TextBox placeholder={TEST_PLACEHOLDER} />);
+    const { container } = render(<MockParent placeholder={TEST_PLACEHOLDER} />);
     const placeholder = screen.getByPlaceholderText(TEST_PLACEHOLDER);
     expect(placeholder).toBeInTheDocument();
 
@@ -33,16 +52,14 @@ describe('TextBox', () => {
   });
 
   it('should work nicely with placeholder when initial text is set', () => {
-    const { container } = render(
-      <TextBox placeholder={TEST_PLACEHOLDER} initialText={TEST_INITIAL_TEXT} />
-    );
+    const { container } = render(<MockParent placeholder={TEST_PLACEHOLDER} value={TEST_VALUE} />);
     const input = getTextBoxInput(container);
-    expect(input).toHaveValue(TEST_INITIAL_TEXT);
+    expect(input).toHaveValue(TEST_VALUE);
     expect(input).not.toHaveValue(TEST_PLACEHOLDER);
   });
 
   it('should change label to legend view when input is focused or non-empty', () => {
-    const { container } = render(<TextBox label={TEST_LABEL} />);
+    const { container } = render(<MockParent label={TEST_LABEL} />);
     const input = getTextBoxInput(container);
     const label = getTextBoxLabel(container);
 

--- a/src/components/text-box/text-box.test.tsx
+++ b/src/components/text-box/text-box.test.tsx
@@ -1,0 +1,80 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { TextBox } from './text-box';
+
+const TEST_LABEL = 'TEST_LABEL';
+const TEST_PLACEHOLDER = 'TEST_PLACEHOLDER';
+const TEST_INITIAL_TEXT = 'TEST_INITIAL_TEXT';
+
+describe('TextBox', () => {
+  it('should render correctly with default props', () => {
+    const { container } = render(<TextBox />);
+    const input = getTextBoxInput(container);
+    expect(input).toHaveAttribute('type', 'text');
+  });
+
+  it('should render label', () => {
+    const { container } = render(<TextBox label={TEST_LABEL} />);
+    const label = getTextBoxLabel(container);
+    expect(label).toBeTruthy();
+    expect(label).toBeInTheDocument();
+  });
+
+  it('should render placeholder', () => {
+    const { container } = render(<TextBox placeholder={TEST_PLACEHOLDER} />);
+    const placeholder = screen.getByPlaceholderText(TEST_PLACEHOLDER);
+    expect(placeholder).toBeInTheDocument();
+
+    // type 'some text'
+    const input = getTextBoxInput(container);
+    fireEvent.change(input, { target: { value: 'some text' } });
+    expect(input).toHaveValue('some text');
+    expect(input).not.toHaveValue(TEST_PLACEHOLDER);
+  });
+
+  it('should work nicely with placeholder when initial text is set', () => {
+    const { container } = render(
+      <TextBox placeholder={TEST_PLACEHOLDER} initialText={TEST_INITIAL_TEXT} />
+    );
+    const input = getTextBoxInput(container);
+    expect(input).toHaveValue(TEST_INITIAL_TEXT);
+    expect(input).not.toHaveValue(TEST_PLACEHOLDER);
+  });
+
+  it('should change label to legend view when input is focused or non-empty', () => {
+    const { container } = render(<TextBox label={TEST_LABEL} />);
+    const input = getTextBoxInput(container);
+    const label = getTextBoxLabel(container);
+
+    const expectLabelIsLegend = () => expect(label).toHaveClass('as-legend');
+    const expectLabelIsNotLegend = () => expect(label).not.toHaveClass('as-legend');
+
+    // check when just focused then unfocus
+    expectLabelIsNotLegend();
+    input.focus();
+    expectLabelIsLegend();
+    input.blur();
+    expectLabelIsNotLegend();
+
+    // check when just non-empty then make empty again
+    expectLabelIsNotLegend();
+    fireEvent.change(input, { target: { value: 'some text' } });
+    expectLabelIsLegend();
+    fireEvent.change(input, { target: { value: '' } }); // make empty
+    expectLabelIsNotLegend();
+
+    // check when both focused and non-empty
+    expectLabelIsNotLegend();
+    input.focus();
+    fireEvent.change(input, { target: { value: 'some text' } });
+    expectLabelIsLegend();
+  });
+
+  function getTextBoxInput(container: HTMLElement): HTMLElement {
+    return container.getElementsByClassName('c-text-box-input')[0] as HTMLElement;
+  }
+
+  function getTextBoxLabel(container: HTMLElement): HTMLElement {
+    return container.getElementsByClassName('c-text-box-label')[0] as HTMLElement;
+  }
+});

--- a/src/components/text-box/text-box.test.tsx
+++ b/src/components/text-box/text-box.test.tsx
@@ -1,19 +1,13 @@
 import React, { useState } from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
-import { TextBox } from './text-box';
+import { TextBox, TextBoxProps } from './text-box';
 
 const TEST_LABEL = 'TEST_LABEL';
 const TEST_PLACEHOLDER = 'TEST_PLACEHOLDER';
 const TEST_VALUE = 'TEST_VALUE';
 
 // text box state is lifted, use this component to propagate changes
-interface MockParentProps {
-  value?: string;
-  label?: string;
-  placeholder?: string;
-}
-
-const MockParent = ({ value, label, placeholder }: MockParentProps) => {
+const MockTextBox = ({ value, label, placeholder }: TextBoxProps) => {
   const [val, setVal] = useState(value ?? '');
   return (
     <TextBox
@@ -27,20 +21,20 @@ const MockParent = ({ value, label, placeholder }: MockParentProps) => {
 
 describe('TextBox', () => {
   it('should render correctly with default props', () => {
-    const { container } = render(<TextBox />);
+    const { container } = render(<MockTextBox />);
     const input = getTextBoxInput(container);
     expect(input).toHaveAttribute('type', 'text');
   });
 
   it('should render label', () => {
-    const { container } = render(<TextBox label={TEST_LABEL} />);
+    const { container } = render(<MockTextBox label={TEST_LABEL} />);
     const label = getTextBoxLabel(container);
     expect(label).toBeTruthy();
     expect(label).toBeInTheDocument();
   });
 
   it('should render placeholder', () => {
-    const { container } = render(<MockParent placeholder={TEST_PLACEHOLDER} />);
+    const { container } = render(<MockTextBox placeholder={TEST_PLACEHOLDER} />);
     const placeholder = screen.getByPlaceholderText(TEST_PLACEHOLDER);
     expect(placeholder).toBeInTheDocument();
 
@@ -52,14 +46,14 @@ describe('TextBox', () => {
   });
 
   it('should work nicely with placeholder when initial text is set', () => {
-    const { container } = render(<MockParent placeholder={TEST_PLACEHOLDER} value={TEST_VALUE} />);
+    const { container } = render(<MockTextBox placeholder={TEST_PLACEHOLDER} value={TEST_VALUE} />);
     const input = getTextBoxInput(container);
     expect(input).toHaveValue(TEST_VALUE);
     expect(input).not.toHaveValue(TEST_PLACEHOLDER);
   });
 
   it('should change label to legend view when input is focused or non-empty', () => {
-    const { container } = render(<MockParent label={TEST_LABEL} />);
+    const { container } = render(<MockTextBox label={TEST_LABEL} />);
     const input = getTextBoxInput(container);
     const label = getTextBoxLabel(container);
 

--- a/src/components/text-box/text-box.tsx
+++ b/src/components/text-box/text-box.tsx
@@ -2,7 +2,7 @@ import React, { useState, KeyboardEvent, ChangeEvent, useRef } from 'react';
 import './text-box.scss';
 
 export interface TextBoxProps {
-  initialText?: string;
+  value?: string;
   inputType?: string; // (e.g. 'text', 'password')
   label?: React.ReactNode;
   placeholder?: string;
@@ -13,7 +13,7 @@ export interface TextBoxProps {
 }
 
 export const TextBox = ({
-  initialText = '',
+  value = '',
   inputType = 'text',
   label,
   placeholder,
@@ -22,7 +22,6 @@ export const TextBox = ({
   className,
   onChange,
 }: TextBoxProps) => {
-  const [value, setValue] = useState(initialText);
   const [isFocused, setFocused] = useState(false);
 
   return (
@@ -51,7 +50,6 @@ export const TextBox = ({
   }
 
   function onChangeHandler(e: ChangeEvent<HTMLInputElement>) {
-    setValue(e.target.value);
     onChange?.(e.target.value);
   }
 };

--- a/src/components/text-box/text-box.tsx
+++ b/src/components/text-box/text-box.tsx
@@ -1,0 +1,57 @@
+import React, { useState, KeyboardEvent, ChangeEvent, useRef } from 'react';
+import './text-box.scss';
+
+export interface TextBoxProps {
+  initialText?: string;
+  inputType?: string; // (e.g. 'text', 'password')
+  label?: React.ReactNode;
+  placeholder?: string;
+  disabled?: boolean;
+  variant?: 'dark' | 'light';
+  className?: string;
+  onChange?: (value: string) => void;
+}
+
+export const TextBox = ({
+  initialText = '',
+  inputType = 'text',
+  label,
+  placeholder,
+  disabled,
+  variant = 'light',
+  className,
+  onChange,
+}: TextBoxProps) => {
+  const [value, setValue] = useState(initialText);
+  const [isFocused, setFocused] = useState(false);
+
+  return (
+    <div className={`c-text-box-wrapper ${variant} ${className ?? ''}`}>
+      {label && (
+        <label className={`c-text-box-label ${shouldShowAsLegend() ? 'as-legend' : ''}`}>
+          {label}
+        </label>
+      )}
+      <input
+        className="c-text-box-input"
+        placeholder={placeholder}
+        value={value}
+        type={inputType}
+        onFocus={() => setFocused(true)}
+        onBlur={() => setFocused(false)}
+        onChange={onChangeHandler}
+        disabled={disabled}
+      />
+    </div>
+  );
+
+  function shouldShowAsLegend() {
+    const hasText = !!value && value.length > 0;
+    return isFocused || hasText;
+  }
+
+  function onChangeHandler(e: ChangeEvent<HTMLInputElement>) {
+    setValue(e.target.value);
+    onChange?.(e.target.value);
+  }
+};


### PR DESCRIPTION
Two variants:
- light (default)
- dark

Philosophy: 
- same philosophy as the text area component
- consumer should subscribe to `onChange` and save the state on their own

![text-box](https://user-images.githubusercontent.com/29434693/160525433-476e1172-9ef7-4346-98d8-952fcf2fa6d8.gif)
