### PR TITLE
added header and sidebar

### DIFF
--- a/src/app.scss
+++ b/src/app.scss
@@ -6,54 +6,61 @@
 }
 
 .App {
-  display: flex;
-  flex-direction: column;
-  justify-content: space-evenly;
-  align-items: center;
-  gap: 32px;
-  min-height: 100vh;
-  height: 100%;
-  padding: 16px;
+  .page-wrap {
+    margin-left: $sidebar-width;
+    padding-top: $header-height;
 
-  .text-areas {
-    display: flex;
-    gap: 16px;
-    // so we can see the labels and stuff
-    background-color: white;
-    padding: 16px;
-    width: 800px;
-  }
+    > .content {
+      display: flex;
+      flex-direction: column;
+      justify-content: space-evenly;
+      align-items: center;
+      gap: 32px;
+      min-height: 100vh;
+      height: 100%;
+      padding: 20px $content-padding;
 
-  .text-box {
-    width: 400px;
-    padding: 16px;
-    background-color: white;
-  }
+      .text-areas {
+        display: flex;
+        gap: 16px;
+        // so we can see the labels and stuff
+        background-color: white;
+        padding: 16px;
+        width: 800px;
+      }
 
-  .text-box-dark {
-    width: 400px;
-    padding: 16px;
-    background-color: $black;
-  }
+      .text-box {
+        width: 400px;
+        padding: 16px;
+        background-color: white;
+      }
 
-  .search-bar {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 400px;
-  }
+      .text-box-dark {
+        width: 400px;
+        padding: 16px;
+        background-color: $black;
+      }
 
-  .improvised-popup {
-    display: flex;
-    flex-direction: column;
-    justify-content: space-evenly;
-    align-items: center;
-    height: 200px;
-    padding: 0px 50px;
-    background-color: white;
-    border-radius: $standard-radius;
-  }
-  .test-drop-down {
-    width: 200px;
+      .search-bar {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: 400px;
+      }
+
+      .improvised-popup {
+        display: flex;
+        flex-direction: column;
+        justify-content: space-evenly;
+        align-items: center;
+        height: 200px;
+        padding: 0px 50px;
+        background-color: white;
+        border-radius: $standard-radius;
+      }
+      .test-drop-down {
+        width: 200px;
+      }
+    }
   }
 }

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -71,7 +71,6 @@ function App() {
           </div>
           <div className="search-bar">
             <SearchBar
-              placeholder="search my decks"
               onChange={() => console.log('changed')}
               debounceMs={500}
               onDebouncedChange={(value: string) => console.log('debounce-changed: ' + value)}

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -8,6 +8,8 @@ import { SearchBar } from './components/search-bar/search-bar';
 import { DropDown, DropDownOption } from './components/drop-down/drop-down';
 import { TextArea } from './components/text-area/text-area';
 import { TextBox } from './components/text-box/text-box';
+import { Sidebar } from './components/sidebar/sidebar';
+import { Header } from './components/header/header';
 
 const testDeck: Deck = {
   id: 0,
@@ -20,6 +22,7 @@ const testDeck: Deck = {
 };
 
 function App() {
+  const [showDecks, setShowDecks] = useState(true);
   const [isActive, setIsActive] = useState(false);
   const [selectedChoice, setSelectedOption] = useState(getOptions()[0]);
 
@@ -31,75 +34,81 @@ function App() {
 
   return (
     <div className="App">
-      <div className="text-areas">
-        <TextArea
-          placeholder="copy and paste your cards here"
-          lines={8}
-          label="a cool label"
-          value={textAreaContent}
-          onChange={(v: string) => setTextAreaContent(v)}
-        />
-        <TextArea
-          lines={8}
-          label="copy your cards"
-          value="what is a gerund; what is a gerund; what is a gerund; what is a gerund;"
-          readonly={true}
-        />
-      </div>
-      <div className="text-box">
-        <TextBox
-          label="username"
-          value={textBoxValue1}
-          onChange={(v: string) => setTextBoxValue1(v)}
-        />
-      </div>
-      <div className="text-box-dark">
-        <TextBox
-          label="username"
-          variant="dark"
-          value={textBoxValue2}
-          onChange={(v: string) => setTextBoxValue2(v)}
-        />
-      </div>
-      <div className="search-bar">
-        <SearchBar
-          placeholder="search my decks"
-          onChange={() => console.log('changed')}
-          onEnterPressed={(value: string) => console.log('enter pressed: ' + value)}
-        />
-      </div>
-      <DeckCover
-        isActive={isActive}
-        onClick={() => setIsActive(!isActive)}
-        deck={testDeck}
-        onEditClick={dummy}
-        onStudyClick={dummy}
-      />
-      <div className="improvised-popup">
-        <DropDown
-          variant="light"
-          className="test-drop-down"
-          label="hello"
-          options={getOptions()}
-          buttonLabel={selectedChoice.value}
-          onOptionSelect={(choice) => {
-            setSelectedOption(choice);
-          }}
-        />
-        <Button variant="light" onClick={dummy}>
-          World
-        </Button>
-      </div>
+      <Header />
+      <Sidebar onFlashcardDecksClick={() => setShowDecks(true)} />
+      <div className="page-wrap">
+        <div className="content">
+          <div className="text-areas">
+            <TextArea
+              placeholder="copy and paste your cards here"
+              lines={8}
+              label="a cool label"
+              value={textAreaContent}
+              onChange={(v: string) => setTextAreaContent(v)}
+            />
+            <TextArea
+              lines={8}
+              label="copy your cards"
+              value="what is a gerund; what is a gerund; what is a gerund; what is a gerund;"
+              readonly={true}
+            />
+          </div>
+          <div className="text-box">
+            <TextBox
+              label="username"
+              value={textBoxValue1}
+              onChange={(v: string) => setTextBoxValue1(v)}
+            />
+          </div>
+          <div className="text-box-dark">
+            <TextBox
+              label="username"
+              variant="dark"
+              value={textBoxValue2}
+              onChange={(v: string) => setTextBoxValue2(v)}
+            />
+          </div>
+          <div className="search-bar">
+            <SearchBar
+              placeholder="search my decks"
+              onChange={() => console.log('changed')}
+              onEnterPressed={(value: string) => console.log('enter pressed: ' + value)}
+            />
+          </div>
+          <DeckCover
+            isActive={isActive}
+            onClick={() => setIsActive(!isActive)}
+            deck={testDeck}
+            onEditClick={dummy}
+            onStudyClick={dummy}
+          />
+          <div className="improvised-popup">
+            <DropDown
+              variant="light"
+              className="test-drop-down"
+              label="hello"
+              options={getOptions()}
+              buttonLabel={selectedChoice.value}
+              onOptionSelect={(choice) => {
+                setSelectedOption(choice);
+              }}
+            />
+            <Button variant="light" onClick={dummy}>
+              World
+            </Button>
+          </div>
 
-      <DropDown
-        variant="dark"
-        buttonLabel={selectedChoice.value}
-        options={getOptions()}
-        onOptionSelect={(choice) => setSelectedOption(choice)}
-      />
-      <Button variant="dark" onClick={dummy}>
-        Hello
-      </Button>
+          <DropDown
+            variant="dark"
+            buttonLabel={selectedChoice.value}
+            options={getOptions()}
+            onOptionSelect={(choice) => setSelectedOption(choice)}
+          />
+          <Button variant="dark" onClick={dummy}>
+            Hello
+          </Button>
+        </div>
+      </div>
     </div>
   );
 }

--- a/src/assets/_styles.scss
+++ b/src/assets/_styles.scss
@@ -1,6 +1,9 @@
 @import './colors';
 
 $standard-radius: 4px;
+$sidebar-width: 260px;
+$header-height: 53px;
+$content-padding: 50px;
 
 @mixin hover($background-color) {
   transition-duration: 200ms;

--- a/src/components/button/button.scss
+++ b/src/components/button/button.scss
@@ -8,6 +8,7 @@
   font-size: 15px;
   box-sizing: border-box;
   border: 1px solid transparent;
+  white-space: nowrap;
 
   &.dark {
     border-color: $light-blue;

--- a/src/components/header/header.scss
+++ b/src/components/header/header.scss
@@ -1,0 +1,42 @@
+@import '../../assets/colors';
+@import '../../assets/styles';
+
+.c-header {
+  position: fixed;
+  height: $header-height;
+  width: 100%;
+  padding-left: $sidebar-width;
+  box-sizing: border-box;
+  background-color: $deck-cover-blue;
+  border-bottom: 1px solid $light-blue;
+
+  .c-header-content {
+    height: 100%;
+    display: flex;
+    align-content: center;
+    justify-content: space-between;
+    margin: 0px $content-padding;
+
+    .c-search-bar-container {
+      @include flex-center;
+      width: 500px;
+    }
+
+    .c-account-buttons {
+      @include flex-center;
+
+      button {
+        padding: 12px;
+        border: none;
+
+        &.sign-up-button {
+          background-color: transparent;
+        }
+
+        &.sign-in-button {
+          background-color: $electric-blue;
+        }
+      }
+    }
+  }
+}

--- a/src/components/header/header.tsx
+++ b/src/components/header/header.tsx
@@ -1,0 +1,32 @@
+import './header.scss';
+import React from 'react';
+import { SearchBar } from '../search-bar/search-bar';
+import { Button } from '../button/button';
+
+export const Header = () => {
+  return (
+    <div className="c-header">
+      <div className="c-header-content">
+        <div className="c-search-bar-container">
+          <SearchBar placeholder="search my decks" />
+        </div>
+        <div className="c-account-buttons">
+          <Button onClick={handleSignUpClick} className="sign-up-button">
+            sign up
+          </Button>
+          <Button onClick={handleSignInClick} className="sign-in-button">
+            sign in
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+
+  function handleSignUpClick() {
+    console.log('sign up');
+  }
+
+  function handleSignInClick() {
+    console.log('sign up');
+  }
+};

--- a/src/components/sidebar/sidebar.scss
+++ b/src/components/sidebar/sidebar.scss
@@ -1,0 +1,41 @@
+@import '../../assets/colors';
+@import '../../assets/styles';
+
+.c-sidebar {
+  width: $sidebar-width;
+  box-sizing: border-box;
+  padding: 0px 20px;
+  height: 100vh;
+  position: fixed;
+  background-color: $blue;
+  color: $white;
+  border-right: 1px solid $light-blue;
+
+  .c-title {
+    margin: 10px 0px;
+    display: inline-block;
+    width: 100%;
+    font-size: 30px;
+    text-align: center;
+
+    span {
+      font-weight: bold;
+    }
+  }
+
+  .c-sidebar-divider {
+    height: 1px;
+    background-color: $light-blue;
+    border: none;
+    margin: 0px;
+  }
+
+  > ul {
+    padding-left: 30px;
+    list-style-type: none;
+    font-size: 20px;
+    li {
+      margin-bottom: 20px;
+    }
+  }
+}

--- a/src/components/sidebar/sidebar.tsx
+++ b/src/components/sidebar/sidebar.tsx
@@ -1,0 +1,23 @@
+import './sidebar.scss';
+import React from 'react';
+interface SidebarProps {
+  onFlashcardDecksClick: (event: React.MouseEvent) => void;
+}
+export const Sidebar = ({ onFlashcardDecksClick }: SidebarProps) => {
+  return (
+    <div className="c-sidebar">
+      <label className="c-title">
+        echo<span>Study</span>
+      </label>
+      <hr className="c-sidebar-divider" />
+      <ul>
+        <li>
+          <a onClick={onFlashcardDecksClick}>flashcard decks</a>
+        </li>
+        <li>create</li>
+        <li>study</li>
+        <li>search</li>
+      </ul>
+    </div>
+  );
+};

--- a/src/components/sidebar/sidebar.tsx
+++ b/src/components/sidebar/sidebar.tsx
@@ -6,7 +6,7 @@ interface SidebarProps {
 export const Sidebar = ({ onFlashcardDecksClick }: SidebarProps) => {
   return (
     <div className="c-sidebar">
-      <label className="c-title">
+      <label className="c-sidebar-title">
         echo<span>Study</span>
       </label>
       <hr className="c-sidebar-divider" />

--- a/src/index.scss
+++ b/src/index.scss
@@ -1,7 +1,7 @@
 @import url('https://fonts.googleapis.com/css2?family=Comfortaa:wght@300;700&display=swap');
 body {
   margin: 0;
-  font-family: 'Comfortaa';
+  font-family: 'Comfortaa', cursive;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }


### PR DESCRIPTION
- I am not sure how we want to handle navigation yet 
  -  For the demo, I assumed we can just have a state bool `showDecks` and this determines if we show the decks or cards of a deck page.
  -  clicking `flashcard decks` in the sidebar will set it to true, and we could set it up so clicking edit on a deck could set it to false
  - We can rework the links later to be a lot more sound
- There is also no handlers set up in the search bar in the header
  - We can add the handlers and mock data for the demo 