### PR TITLE
Text area dark variant and animate label as legend

### DIFF
--- a/src/components/deck-editor/meta-data-editor/meta-data-editor.scss
+++ b/src/components/deck-editor/meta-data-editor/meta-data-editor.scss
@@ -42,14 +42,10 @@
     align-items: flex-end;
     gap: 16px;
 
-    // Todo add dark variant to text area
     textarea {
-      background-color: $black;
-      color: $white;
-      border-color: $light-blue;
+      padding: 12px 12px;
       height: 58px;
       border-radius: 10px;
-      outline: none;
     }
   }
 

--- a/src/components/deck-editor/meta-data-editor/meta-data-editor.tsx
+++ b/src/components/deck-editor/meta-data-editor/meta-data-editor.tsx
@@ -43,6 +43,8 @@ export const MetaDataEditor = ({ label, deck, onDeckChange }: DeckEditorProps) =
       <div className="c-description-and-import-buttons">
         <TextArea
           lines={2}
+          label="description"
+          variant="dark"
           placeholder="add a description"
           value={deck.desc}
           onChange={handleDeckDescChange}

--- a/src/components/text-area/text-area.scss
+++ b/src/components/text-area/text-area.scss
@@ -5,44 +5,88 @@
 // textarea also supports a 'col' attribute: 'col=20' => fit 20 characters per row
 // using this attribute would mean being able to remove `width: 100%` definitions in CSS
 
+$label-font-size: 14px;
+$label-legend-font-size: 12px;
+
 .c-text-area-wrapper {
     display: flex;
     flex-direction: column;
     gap: 4px;
     box-sizing: border-box;
     width: 100%;
+}
 
-    .c-text-area-label {
+.c-text-area-label {
+    width: fit-content;
+    min-height: $label-font-size;
+    padding: 0px 2px;
+    font-size: $label-font-size;
+    transition: transform 100ms ease-in-out;
+
+    &.as-legend {
+        font-size: $label-legend-font-size;
+        padding: 0px 4px;
+        transform: translate(16px, $label-font-size - 2px);
+    }
+
+    .light & {
+        background-color: $white;
         color: $grey;
     }
 
-    .c-text-area {
-        font-family: "Comfortaa";
-        color: $blue;
-        border-color: $grey;
-        border-radius: $standard-radius;
-        box-sizing: border-box;
-        padding: 16px;
-        width: 100%;
+    .dark & {
+        background-color: $black;
+        color: $light-blue;
+    }
+}
 
-        &.readonly {
-            background-color: $flashcard-white;
-        }
+.c-text-area {
+    font-family: "Comfortaa";
+    border: 1px solid $white;
+    border-radius: $standard-radius;
+    box-sizing: border-box;
+    outline: none;
+    padding: 16px;
+    width: 100%;
+
+    .light & {
+        background-color: $white;
+        border-color: $grey;
+        color: $blue;
 
         &:focus, &:focus-visible {
+            outline: auto;
             outline-color: $grey;
         }
     }
 
-    .c-text-area-footer {
-        display: flex;
-        padding: 0px 2px;
-        gap: 4px;
+    .dark & {
+        border-color: $light-blue;
+        color: $white;
+        background-color: $black;
+    }
 
-        > label {
-            padding-top: 1px;
+    &.readonly {
+        background-color: $flashcard-white;
+        color: $blue;
+    }
+}
+
+.c-text-area-footer {
+    display: flex;
+    padding: 0px 2px;
+    gap: 4px;
+
+    > label {
+        padding-top: 1px;
+        font-size: 10px;
+
+        .light & {
             color: $grey;
-            font-size: 10px;
+        }
+
+        .dark & {
+            color: $light-blue;
         }
     }
 }

--- a/src/components/text-area/text-area.test.tsx
+++ b/src/components/text-area/text-area.test.tsx
@@ -8,13 +8,22 @@ const TEST_PLACEHOLDER = 'TEST_PLACEHOLDER';
 const TEST_VALUE = 'TEST_VALUE';
 
 // text box state is lifted, use this component to propagate changes
-const MockTextArea = ({ lines, value, label, placeholder, readonly, onChange }: TextAreaProps) => {
+const MockTextArea = ({
+  lines,
+  value,
+  label,
+  animateLabelAsLegend,
+  placeholder,
+  readonly,
+  onChange,
+}: TextAreaProps) => {
   const [val, setVal] = useState(value ?? '');
   return (
     <TextArea
       lines={lines}
       value={val}
       label={label}
+      animateLabelAsLegend={animateLabelAsLegend}
       placeholder={placeholder}
       readonly={readonly}
       onChange={(v: string) => {
@@ -82,6 +91,54 @@ describe('TextArea', () => {
 
     // check the first argument of the first call
     expect(callsRef[0][0]).toBe('some text');
+  });
+
+  it('should change label to legend view when input is focused or non-empty', () => {
+    const { container } = render(<MockTextArea lines={LINES} label={TEST_LABEL} />);
+    const textArea = getTextArea(container);
+    const label = getTextAreaLabel(container);
+
+    const expectLabelIsLegend = () => expect(label).toHaveClass('as-legend');
+    const expectLabelIsNotLegend = () => expect(label).not.toHaveClass('as-legend');
+
+    // check when just focused then unfocus
+    expectLabelIsNotLegend();
+    textArea.focus();
+    expectLabelIsLegend();
+    textArea.blur();
+    expectLabelIsNotLegend();
+
+    // check when just non-empty then make empty again
+    expectLabelIsNotLegend();
+    fireEvent.change(textArea, { target: { value: 'some text' } });
+    expectLabelIsLegend();
+    fireEvent.change(textArea, { target: { value: '' } }); // make empty
+    expectLabelIsNotLegend();
+
+    // check when both focused and non-empty
+    expectLabelIsNotLegend();
+    textArea.focus();
+    fireEvent.change(textArea, { target: { value: 'some text' } });
+    expectLabelIsLegend();
+  });
+
+  it('should not animate label to legend if setting is disabled', () => {
+    const { container } = render(
+      <MockTextArea lines={LINES} label={TEST_LABEL} animateLabelAsLegend={false} />
+    );
+    const textArea = getTextArea(container);
+    const label = getTextAreaLabel(container);
+
+    const expectLabelIsNotLegend = () => expect(label).not.toHaveClass('as-legend');
+
+    // check when focused
+    expectLabelIsNotLegend();
+    textArea.focus();
+    expectLabelIsNotLegend();
+
+    // check with text (also still focused)
+    fireEvent.change(textArea, { target: { value: 'some text' } });
+    expectLabelIsNotLegend();
   });
 
   function getTextArea(container: HTMLElement): HTMLElement {

--- a/src/components/text-area/text-area.tsx
+++ b/src/components/text-area/text-area.tsx
@@ -6,9 +6,11 @@ export interface TextAreaProps {
   lines: number;
   value?: string;
   label?: React.ReactNode;
+  animateLabelAsLegend?: boolean;
   placeholder?: string;
   readonly?: boolean;
   resizable?: boolean; // default: false
+  variant?: 'light' | 'dark';
   onChange?: (value: string) => void;
 }
 
@@ -16,14 +18,22 @@ export const TextArea = ({
   lines,
   value = '',
   label,
+  animateLabelAsLegend = true,
   placeholder,
   readonly,
   resizable,
+  variant = 'light',
   onChange,
 }: TextAreaProps) => {
+  const [isFocused, setFocused] = useState(false);
+
   return (
-    <div className="c-text-area-wrapper">
-      {label && <label className="c-text-area-label">{label}</label>}
+    <div className={`c-text-area-wrapper ${variant}`}>
+      {label && (
+        <label className={`c-text-area-label ${shouldShowAsLegend() ? 'as-legend' : ''}`}>
+          {label}
+        </label>
+      )}
       <textarea
         className={`c-text-area ${readonly ? 'readonly' : ''}`}
         rows={lines}
@@ -32,10 +42,17 @@ export const TextArea = ({
         style={{ resize: resizable ? 'both' : 'none' }}
         value={value}
         onChange={onChangeHandler}
+        onFocus={() => setFocused(true)}
+        onBlur={() => setFocused(false)}
       />
       {readonly && getReadonlyFooter()}
     </div>
   );
+
+  function shouldShowAsLegend() {
+    const hasText = !!value && value.length > 0;
+    return animateLabelAsLegend && (isFocused || hasText);
+  }
 
   function getReadonlyFooter() {
     return (

--- a/src/components/text-box/text-box.tsx
+++ b/src/components/text-box/text-box.tsx
@@ -1,4 +1,4 @@
-import React, { useState, KeyboardEvent, ChangeEvent, useRef } from 'react';
+import React, { useState, ChangeEvent } from 'react';
 import './text-box.scss';
 
 export interface TextBoxProps {


### PR DESCRIPTION
- dark variant added to text-area component
- animate label as legend via `animateLabelAsLegend` prop (default: `true`)
- cleaned up some unused imports

![text-area-legend-and-dark-variant](https://user-images.githubusercontent.com/29434693/162349906-0ffa4303-216b-4853-8410-3de858b68203.gif)
