### PR TITLE
Add popup modal

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -29,6 +29,7 @@
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
+    <div id="portal"></div>
     <!--
       This HTML file is a template.
       If you open it directly in the browser, you will see an empty page.

--- a/src/assets/icons/cancel-icon/cancel-icon.scss
+++ b/src/assets/icons/cancel-icon/cancel-icon.scss
@@ -1,0 +1,15 @@
+@import '../../colors';
+@import '../../styles';
+
+svg.cancel-icon {
+  @include standard-transition;
+  @include hover-pointer;
+
+  &.dark path {
+    stroke: $blue;
+  }
+
+  &.light path {
+    stroke: $white;
+  }
+}

--- a/src/assets/icons/cancel-icon/cancel-icon.tsx
+++ b/src/assets/icons/cancel-icon/cancel-icon.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { noop } from '../../../helpers/func';
+import { ReactComponent as CancelIconSvg } from '../../svg/cancel-icon.svg';
+import './cancel-icon.scss';
+
+interface CancelIconProps {
+  variant?: 'dark' | 'light';
+  className?: string;
+  onClick?: (event: React.MouseEvent) => void;
+}
+
+export const CancelIcon = ({
+  variant = 'light',
+  className = '',
+  onClick = noop,
+}: CancelIconProps) => {
+  return <CancelIconSvg className={`cancel-icon ${variant} ${className}`} onClick={onClick} />;
+};

--- a/src/components/deck-editor/meta-data-editor/meta-data-editor.tsx
+++ b/src/components/deck-editor/meta-data-editor/meta-data-editor.tsx
@@ -1,5 +1,5 @@
 import './meta-data-editor.scss';
-import React from 'react';
+import React, { useState } from 'react';
 import { Deck } from '../../../models/deck';
 import { Button } from '../../button/button';
 import { TextBox } from '../../text-box/text-box';
@@ -7,6 +7,8 @@ import { BubbleDivider } from '../../bubble-divider/bubble-divider';
 import { DropDown, DropDownOption } from '../../drop-down/drop-down';
 import { Language } from '../../../models/card-content';
 import { TextArea } from '../../text-area/text-area';
+import { PopupModal } from '../../popup-modal/popup-modal';
+import { findByLabelText } from '@testing-library/react';
 
 // Todo: maybe change Language to be enum instead of type
 enum Languages {
@@ -23,6 +25,8 @@ interface DeckEditorProps {
 }
 
 export const MetaDataEditor = ({ label, deck, onDeckChange }: DeckEditorProps) => {
+  const [showImportModal, setShowImportModal] = useState(false);
+
   return (
     <div className="deck-meta">
       <div className="deck-editor-header">
@@ -52,6 +56,7 @@ export const MetaDataEditor = ({ label, deck, onDeckChange }: DeckEditorProps) =
         <Button onClick={handleImportClick} className="editor-button">
           import cards
         </Button>
+        {getImportPopupModal()}
         <Button onClick={handleExportClick} className="editor-button">
           export deck
         </Button>
@@ -82,6 +87,20 @@ export const MetaDataEditor = ({ label, deck, onDeckChange }: DeckEditorProps) =
       </BubbleDivider>
     </div>
   );
+
+  function getImportPopupModal() {
+    return (
+      <PopupModal
+        headerLabel="Import Popup"
+        showTrigger={showImportModal}
+        onClose={() => setShowImportModal(false)}
+      >
+        <p>example popup example popup example popup example popup</p>
+        <BubbleDivider label="or" />
+        <p>example popup example popup example popup example popup</p>
+      </PopupModal>
+    );
+  }
 
   function handleDeckDeleteClick(event: React.MouseEvent) {
     // Todo: finish
@@ -115,6 +134,7 @@ export const MetaDataEditor = ({ label, deck, onDeckChange }: DeckEditorProps) =
   function handleImportClick() {
     //Todo: finish
     console.log('clicked!');
+    setShowImportModal(true);
   }
 
   function handleExportClick() {

--- a/src/components/deck-editor/meta-data-editor/meta-data-editor.tsx
+++ b/src/components/deck-editor/meta-data-editor/meta-data-editor.tsx
@@ -8,7 +8,6 @@ import { DropDown, DropDownOption } from '../../drop-down/drop-down';
 import { Language } from '../../../models/card-content';
 import { TextArea } from '../../text-area/text-area';
 import { PopupModal } from '../../popup-modal/popup-modal';
-import { findByLabelText } from '@testing-library/react';
 
 // Todo: maybe change Language to be enum instead of type
 enum Languages {
@@ -96,7 +95,10 @@ export const MetaDataEditor = ({ label, deck, onDeckChange }: DeckEditorProps) =
         onClose={() => setShowImportModal(false)}
       >
         <p>example popup example popup example popup example popup</p>
-        <BubbleDivider label="or" />
+        <p>
+          <textarea />
+        </p>
+        <button onClick={() => alert('clicked in content of modal')}>inner button</button>
         <p>example popup example popup example popup example popup</p>
       </PopupModal>
     );

--- a/src/components/popup-modal/popup-modal.scss
+++ b/src/components/popup-modal/popup-modal.scss
@@ -1,0 +1,48 @@
+@import url('https://fonts.googleapis.com/css2?family=Comfortaa:wght@300;700&display=swap');
+@import '../../assets/colors';
+@import '../../assets/styles';
+
+$bg-opacity: 0.33; // opacity to set background if modal is open
+$x-axis: 50%; // where to place popup on x-axis
+$y-axis: 25%; // where to place popup on y-axis
+$modal-z-index: 1000;
+
+.c-popup-modal-overlay {
+  z-index: $modal-z-index;
+  position: fixed;
+  inset: 0;
+  min-width: 100%;
+  min-height: 100%;
+  background-color: rgba(0, 0, 0, $bg-opacity);
+  transition: visibility 150ms ease-out, opacity 150ms ease-out;
+
+  &.visible {
+    visibility: visible;
+    opacity: 1;
+  }
+
+  &.hidden {
+    visibility: hidden;
+    opacity: 0;
+  }
+}
+
+.c-popup-modal-content {
+  z-index: $modal-z-index;
+  position: absolute;
+  left: $x-axis;
+  top: $y-axis;
+  transform: translate(-$x-axis, -$y-axis); // center on axis based on content size
+  background: $white;
+  padding: 16px 24px;
+  border-radius: 16px;
+
+  .c-popup-modal-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    color: $blue;
+    font-weight: bold;
+    font-size: 20px;
+  }
+}

--- a/src/components/popup-modal/popup-modal.scss
+++ b/src/components/popup-modal/popup-modal.scss
@@ -42,6 +42,7 @@ $modal-z-index: 1000;
     justify-content: space-between;
     align-items: center;
     color: $blue;
+    font-family: 'Comfortaa';
     font-weight: bold;
     font-size: 20px;
   }

--- a/src/components/popup-modal/popup-modal.test.tsx
+++ b/src/components/popup-modal/popup-modal.test.tsx
@@ -1,8 +1,101 @@
-import { render } from '@testing-library/react';
-import { PopupModal } from './popup-modal';
+import React, { useState } from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { PopupModal, PopupModalProps } from './popup-modal';
+import userEvent from '@testing-library/user-event';
+
+const TEST_CHILDREN = 'TEST_CHILDREN';
+
+const MockPopupModalParent = ({
+  children,
+  headerLabel,
+  outsideClickFiresOnClose,
+}: Partial<PopupModalProps>) => {
+  const [showModal, setShowModal] = useState(false);
+  return (
+    <>
+      <button data-testid="show-modal-button" onClick={() => setShowModal(true)} />
+      <PopupModal
+        headerLabel={headerLabel}
+        showTrigger={showModal}
+        outsideClickFiresOnClose={outsideClickFiresOnClose}
+        onClose={() => setShowModal(false)}
+      >
+        {children}
+      </PopupModal>
+    </>
+  );
+};
 
 describe('PopupModal', () => {
-  it('should render correctly with default props', () => {
-    expect(true).toBeTruthy();
+  beforeEach(() => {
+    // setup portal element for modal to render on
+    document.body.innerHTML = `<div id="portal"></div>`;
   });
+
+  it('should render correctly with default props', () => {
+    const { container } = render(<MockPopupModalParent />);
+    expect(container).toBeInTheDocument();
+  });
+
+  it('should open modal when button hooked up with `showTrigger` is clicked', () => {
+    render(<MockPopupModalParent />);
+    expectModalIsHidden();
+
+    openModal();
+    expectModalIsVisible();
+  });
+
+  it('should hide modal when close button is clicked', () => {
+    render(<MockPopupModalParent />);
+    openModal();
+    expectModalIsVisible();
+
+    closeModal();
+    expectModalIsHidden();
+  });
+
+  it('should hide modal when clicking outside with `outsideClickFiresOnClose` enabled', () => {
+    render(<MockPopupModalParent outsideClickFiresOnClose={true} />);
+    openModal();
+    expectModalIsVisible();
+
+    // simulate clicking outside modal
+    userEvent.click(document.body);
+    expectModalIsHidden();
+  });
+
+  it('should render special children props', () => {
+    const { rerender } = render(<MockPopupModalParent />);
+    openModal();
+    expect(getModalContent()).not.toHaveTextContent(TEST_CHILDREN);
+
+    // rerender with children
+    rerender(<MockPopupModalParent>{TEST_CHILDREN}</MockPopupModalParent>);
+    expect(getModalContent()).toHaveTextContent(TEST_CHILDREN);
+  });
+
+  function expectModalIsHidden() {
+    const wrapper = document.querySelector('.c-popup-modal-overlay');
+    expect(wrapper).toHaveClass('hidden');
+  }
+
+  function expectModalIsVisible() {
+    const wrapper = document.querySelector('.c-popup-modal-overlay');
+    expect(wrapper).toHaveClass('visible');
+  }
+
+  function getModalContent() {
+    return document.querySelector('.c-popup-modal-content') as HTMLElement;
+  }
+
+  function openModal() {
+    const button = screen.getByTestId('show-modal-button');
+    button.click(); // sets showTrigger to true
+  }
+
+  function closeModal() {
+    const cancelIcon = document.querySelector('.cancel-icon');
+    if (!cancelIcon) fail('Could not find cancel icon to close modal');
+    fireEvent.click(cancelIcon);
+  }
 });

--- a/src/components/popup-modal/popup-modal.test.tsx
+++ b/src/components/popup-modal/popup-modal.test.tsx
@@ -1,0 +1,8 @@
+import { render } from '@testing-library/react';
+import { PopupModal } from './popup-modal';
+
+describe('PopupModal', () => {
+  it('should render correctly with default props', () => {
+    expect(true).toBeTruthy();
+  });
+});

--- a/src/components/popup-modal/popup-modal.tsx
+++ b/src/components/popup-modal/popup-modal.tsx
@@ -1,8 +1,8 @@
-import React, { useEffect, useLayoutEffect, useRef, useState } from 'react';
+import React, { useRef } from 'react';
 import ReactDOM from 'react-dom';
 import { CancelIcon } from '../../assets/icons/cancel-icon/cancel-icon';
 import { useFocusFirst } from '../../hooks/use-focus-first';
-import { useFocusTrap, FOCUSABLE_ELEMENTS_QUERY } from '../../hooks/use-focus-trap';
+import { useFocusTrap } from '../../hooks/use-focus-trap';
 import { useOutsideClick } from '../../hooks/use-outside-click';
 import './popup-modal.scss';
 

--- a/src/components/popup-modal/popup-modal.tsx
+++ b/src/components/popup-modal/popup-modal.tsx
@@ -1,6 +1,8 @@
-import React, { useRef, useState } from 'react';
+import React, { useEffect, useLayoutEffect, useRef, useState } from 'react';
 import ReactDOM from 'react-dom';
 import { CancelIcon } from '../../assets/icons/cancel-icon/cancel-icon';
+import { useFocusFirst } from '../../hooks/use-focus-first';
+import { useFocusTrap, FOCUSABLE_ELEMENTS_QUERY } from '../../hooks/use-focus-trap';
 import { useOutsideClick } from '../../hooks/use-outside-click';
 import './popup-modal.scss';
 
@@ -14,24 +16,29 @@ export interface PopupModalProps {
 
 export const PopupModal = ({
   children,
-  headerLabel,
+  headerLabel = '',
   showTrigger,
   outsideClickFiresOnClose = false,
   onClose,
 }: PopupModalProps) => {
-  const contentRef = useRef(null);
-  const iconRef = useRef(null);
+  // handle clicking outside modal if `outsideClickFiresOnClose` is enabled
+  const contentRef = useRef<HTMLDivElement>(null);
   useOutsideClick(contentRef, () => onClose(), outsideClickFiresOnClose);
 
+  // trap accessibility controls (i.e. tabbing) in the content
+  useFocusTrap(contentRef);
+
+  // accessibility: auto-focus the first focusable element (if any)
+  useFocusFirst(contentRef, showTrigger);
+
+  // render onto <div id="portal"></div> instead of in parent hierarchy but still propagate events
   return ReactDOM.createPortal(
     <>
       <div className={`c-popup-modal-overlay ${showTrigger ? 'visible' : 'hidden'}`}>
         <div className="c-popup-modal-content" ref={contentRef}>
           <div className="c-popup-modal-header">
-            {headerLabel}
-            <div ref={iconRef}>
-              <CancelIcon variant="dark" onClick={onClose} />
-            </div>
+            <span>{headerLabel}</span>
+            <CancelIcon variant="dark" onClick={onClose} />
           </div>
           {children}
         </div>

--- a/src/components/popup-modal/popup-modal.tsx
+++ b/src/components/popup-modal/popup-modal.tsx
@@ -1,0 +1,42 @@
+import React, { useRef, useState } from 'react';
+import ReactDOM from 'react-dom';
+import { CancelIcon } from '../../assets/icons/cancel-icon/cancel-icon';
+import { useOutsideClick } from '../../hooks/use-outside-click';
+import './popup-modal.scss';
+
+export interface PopupModalProps {
+  children: React.ReactNode;
+  headerLabel?: React.ReactNode;
+  showTrigger: boolean;
+  outsideClickFiresOnClose?: boolean;
+  onClose: () => void;
+}
+
+export const PopupModal = ({
+  children,
+  headerLabel,
+  showTrigger,
+  outsideClickFiresOnClose = false,
+  onClose,
+}: PopupModalProps) => {
+  const contentRef = useRef(null);
+  const iconRef = useRef(null);
+  useOutsideClick(contentRef, () => onClose(), outsideClickFiresOnClose);
+
+  return ReactDOM.createPortal(
+    <>
+      <div className={`c-popup-modal-overlay ${showTrigger ? 'visible' : 'hidden'}`}>
+        <div className="c-popup-modal-content" ref={contentRef}>
+          <div className="c-popup-modal-header">
+            {headerLabel}
+            <div ref={iconRef}>
+              <CancelIcon variant="dark" onClick={onClose} />
+            </div>
+          </div>
+          {children}
+        </div>
+      </div>
+    </>,
+    document.getElementById('portal') as HTMLElement
+  );
+};

--- a/src/components/search-bar/search-bar.scss
+++ b/src/components/search-bar/search-bar.scss
@@ -21,17 +21,18 @@ $font-size: 20px;
     .c-search-icon-container {
       @include flex-center;
       width: $height;
-      height: $height; 
+      height: $height;
       transition: all 100ms ease-in-out;
-  
+
       &.has-text {
         border-right: 1px solid $light-blue;
         background-color: $blue;
       }
-  
-      .c-search-icon {}
+
+      .c-search-icon {
+      }
     }
-  
+
     .c-search-bar-input {
       flex: auto;
       font-family: 'Comfortaa';
@@ -44,20 +45,14 @@ $font-size: 20px;
       padding-left: 8px;
       box-sizing: border-box;
     }
-  
+
     .c-cancel-icon-container {
       display: none;
       width: $height;
       height: $height;
-  
+
       &.has-text {
         @include flex-center;
-      }
-  
-      .c-cancel-icon {
-        &:hover {
-          cursor: pointer;
-        }
       }
     }
   }
@@ -95,7 +90,7 @@ $font-size: 20px;
       border-bottom: 1px solid $flashcard-white;
     }
   }
-  
+
   &.hidden {
     transition: visibility 0s 100ms, opacity 100ms ease-out;
     visibility: hidden;

--- a/src/components/search-bar/search-bar.test.tsx
+++ b/src/components/search-bar/search-bar.test.tsx
@@ -99,7 +99,7 @@ describe('SearchBar', () => {
   }
 
   function getClearButton(container: HTMLElement): HTMLElement {
-    return container.getElementsByClassName('c-cancel-icon')[0] as HTMLElement;
+    return container.getElementsByClassName('cancel-icon')[0] as HTMLElement;
   }
 
   function getDropdown(container: HTMLElement): HTMLElement {

--- a/src/components/search-bar/search-bar.tsx
+++ b/src/components/search-bar/search-bar.tsx
@@ -1,5 +1,5 @@
 import React, { useState, KeyboardEvent, ChangeEvent, useMemo, useRef } from 'react';
-import { ReactComponent as CancelIcon } from '../../assets/svg/cancel-icon.svg';
+import { CancelIcon } from '../../assets/icons/cancel-icon/cancel-icon';
 import { ReactComponent as SearchIcon } from '../../assets/svg/search-icon.svg';
 import { debounce, noop } from '../../helpers/func';
 import { includesIgnoreCase } from '../../helpers/string';
@@ -61,7 +61,7 @@ export const SearchBar = ({
           disabled={disabled}
         />
         <div className={`c-cancel-icon-container ${hasText() ? 'has-text' : ''}`}>
-          <CancelIcon className="c-cancel-icon" onClick={() => setValue('')} />
+          <CancelIcon variant="light" onClick={() => setValue('')} />
         </div>
       </div>
       <div className={`c-drop-down ${shouldShowDropDown() ? '' : 'hidden'}`}>

--- a/src/components/text-box/text-box.test.tsx
+++ b/src/components/text-box/text-box.test.tsx
@@ -7,7 +7,7 @@ const TEST_PLACEHOLDER = 'TEST_PLACEHOLDER';
 const TEST_VALUE = 'TEST_VALUE';
 
 // text box state is lifted, use this component to propagate changes
-const MockTextBox = ({ value, label, placeholder }: TextBoxProps) => {
+const MockTextBox = ({ value, label, placeholder }: Partial<TextBoxProps>) => {
   const [val, setVal] = useState(value ?? '');
   return (
     <TextBox

--- a/src/hooks/use-focus-first.ts
+++ b/src/hooks/use-focus-first.ts
@@ -1,0 +1,33 @@
+import { RefObject, useEffect } from 'react';
+import { FOCUSABLE_ELEMENTS_QUERY } from './use-focus-trap';
+
+/**
+ * Trap accessibility focus within the ref object.
+ *
+ * @param ref a reference to an HTMLElement, attach object from `useRef` to this
+ * @param active conditionally enable this hook (default: true [always enabled])
+ * @param timeout workaround for unfocusable elements in the case of animations or ref hooking
+ * @param extraDeps extra dependencies to rehook; do NOT include types in `active`
+ */
+export const useFocusFirst = (
+  ref: RefObject<HTMLElement>,
+  active = true,
+  timeout = 100,
+  ...extraDeps: unknown[]
+): void => {
+  useEffect(() => {
+    let timeoutId: ReturnType<typeof setTimeout>;
+
+    if (active) {
+      const focusableNodes = ref?.current?.querySelectorAll(FOCUSABLE_ELEMENTS_QUERY);
+      const firstFocusableElement = focusableNodes?.item(0) as HTMLElement;
+      if (!firstFocusableElement) return;
+
+      // workaround for ref & animation making element unfocusable immediately
+      timeoutId = setTimeout(() => firstFocusableElement.focus(), timeout);
+    }
+
+    // destructor; called when component using this hook gets destroyed or a dependency changes
+    return () => clearTimeout(timeoutId);
+  }, [ref, active, ...extraDeps]);
+};

--- a/src/hooks/use-focus-trap.ts
+++ b/src/hooks/use-focus-trap.ts
@@ -1,4 +1,4 @@
-import { RefObject, useEffect, useLayoutEffect } from 'react';
+import { RefObject, useEffect } from 'react';
 
 export const FOCUSABLE_ELEMENTS = [
   'a[href]',
@@ -32,7 +32,6 @@ export const useFocusTrap = (
       // handle TAB key
       if (event.key === 'Tab') {
         const focusableNodes = ref?.current?.querySelectorAll(FOCUSABLE_ELEMENTS_QUERY);
-        debugger;
         if (!focusableNodes) return;
 
         const firstFocusableElement = focusableNodes.item(0) as HTMLElement;

--- a/src/hooks/use-focus-trap.ts
+++ b/src/hooks/use-focus-trap.ts
@@ -1,0 +1,69 @@
+import { RefObject, useEffect, useLayoutEffect } from 'react';
+
+export const FOCUSABLE_ELEMENTS = [
+  'a[href]',
+  'area[href]',
+  'input:not([disabled])',
+  'select:not([disabled])',
+  'textarea:not([disabled])',
+  'button:not([disabled])',
+  '[tabindex="0"]',
+];
+
+// to be used in document.querySelectorAll(...)
+export const FOCUSABLE_ELEMENTS_QUERY = FOCUSABLE_ELEMENTS.join(',');
+
+/**
+ * Trap accessibility focus within the ref object.
+ *
+ * @param ref a reference to an HTMLElement, attach object from `useRef` to this
+ * @param active conditionally enable this hook (default: true [always enabled])
+ * @param extraDeps extra dependencies to rehook; do NOT include types in `active`
+ */
+export const useFocusTrap = (
+  ref: RefObject<HTMLElement>,
+  active = true,
+  ...extraDeps: unknown[]
+): void => {
+  useEffect(() => {
+    if (!active) return;
+
+    const keyListener = (event: KeyboardEvent) => {
+      // handle TAB key
+      if (event.key === 'Tab') {
+        const focusableNodes = ref?.current?.querySelectorAll(FOCUSABLE_ELEMENTS_QUERY);
+        debugger;
+        if (!focusableNodes) return;
+
+        const firstFocusableElement = focusableNodes.item(0) as HTMLElement;
+        const lastFocusableElement = focusableNodes.item(focusableNodes.length - 1) as HTMLElement;
+
+        // was the only focusable element, keep focus
+        if (firstFocusableElement === lastFocusableElement) {
+          firstFocusableElement.focus();
+          event.preventDefault();
+          return;
+        }
+
+        // handle SHIFT + TAB on first element (reverse wrap to end)
+        if (event.shiftKey && document.activeElement === firstFocusableElement) {
+          event.preventDefault();
+          lastFocusableElement.focus();
+        }
+        // handle TAB on last element (wrap to first)
+        else if (document.activeElement === lastFocusableElement) {
+          event.preventDefault();
+          firstFocusableElement.focus();
+        }
+      }
+    };
+
+    document.addEventListener('keydown', keyListener);
+
+    // destructor; called when component using this hook gets destroyed or a dependency changes
+    return () => {
+      if (!active) return;
+      document.removeEventListener('keydown', keyListener);
+    };
+  }, [ref, active, ...extraDeps]);
+};

--- a/src/hooks/use-outside-click.ts
+++ b/src/hooks/use-outside-click.ts
@@ -25,7 +25,7 @@ export const useOutsideClick = (
 
     document.addEventListener('mousedown', handleOutsideClick);
 
-    // destructor; called when component using this hook gets destroyed
+    // destructor; called when component using this hook gets destroyed or a dependency changes
     return () => {
       if (!active) return;
       document.removeEventListener('mousedown', handleOutsideClick);

--- a/src/hooks/use-outside-click.ts
+++ b/src/hooks/use-outside-click.ts
@@ -2,20 +2,33 @@ import { RefObject, useEffect } from 'react';
 
 /**
  * Perform an action (callback) whenever a click occurs outside of the ref object.
+ *
  * @param ref a reference to an HTMLElement, attach object from `useRef` to this
+ * @param action callback handler after a click outside occurs
+ * @param active conditionally enable this hook (default: true [always enabled])
+ * @param extraDeps extra dependencies to rehook; do NOT include types in `active`
  */
-// eslint-disable-next-line @typescript-eslint/ban-types
-export const useOutsideClick = (ref: RefObject<HTMLElement>, action: Function): void => {
+export const useOutsideClick = (
+  ref: RefObject<HTMLElement>,
+  action: (event: MouseEvent) => void,
+  active = true,
+  ...extraDeps: unknown[]
+): void => {
   useEffect(() => {
+    if (!active) return;
+
     const handleOutsideClick = (event: MouseEvent) => {
       if (ref.current && !ref.current.contains(event.target as Node)) {
-        action();
+        action(event);
       }
     };
 
     document.addEventListener('mousedown', handleOutsideClick);
 
     // destructor; called when component using this hook gets destroyed
-    return () => document.removeEventListener('mousedown', handleOutsideClick);
-  }, [ref]);
+    return () => {
+      if (!active) return;
+      document.removeEventListener('mousedown', handleOutsideClick);
+    };
+  }, [ref, action, active, ...extraDeps]);
 };


### PR DESCRIPTION
just gonna document everything I did here, perhaps a little too verbose but the more the merrier 🤷 

- new popup modal component
  - **(lifted state):** consumer of modal handles `showTrigger` and `onClose`  
  - **(optional prop):** close modal when clicking outside of the modal contents
  - new `useFocusTrap` hook to force accessibility navigation (`Tab` key) inside a parent ref
    - can repurpose/use this to select specific elements when tabbing in the `meta-data-editor`
  - new `useFocusFirst` hook to auto-focus the first element inside a parent ref
  - use React portals to render modal outside of parent DOM while still propagating events
    - **advantages:** less style conflicts (z-index, absolute styling), less rerenders
- change `cancel-icon.svg` to `CancelIcon` component

https://user-images.githubusercontent.com/29434693/162556016-02c69329-a96e-43f3-b289-9c8e7c0472e7.mp4


