### PR TITLE
Fix bubble divider overflow breaking children layout

### DIFF
--- a/src/components/bubble-divider/bubble-divider.scss
+++ b/src/components/bubble-divider/bubble-divider.scss
@@ -13,10 +13,10 @@
     padding: 10px 20px;
 
     .c-bubble-divider-arrow {
-        @include flex-center;
-        height: 100%;
-        padding-left: 10px;
-        fill: $light-blue;
+      @include flex-center;
+      height: 100%;
+      padding-left: 10px;
+      fill: $light-blue;
     }
 
     &.divider:hover {
@@ -37,15 +37,15 @@
       color: $grey;
       border-color: $grey;
       background-color: $white;
-      
+
       &.divider:hover {
         background-color: $white;
       }
-  
+
       &.drop-down {
         @include white-hover;
       }
-      
+
       .c-bubble-divider-arrow {
         fill: $grey;
       }
@@ -55,8 +55,4 @@
       border-color: $grey;
     }
   }
-}
-
-.c-bubble-divider-children {
-  overflow: hidden;
 }

--- a/src/components/bubble-divider/bubble-divider.tsx
+++ b/src/components/bubble-divider/bubble-divider.tsx
@@ -38,8 +38,8 @@ export const BubbleDivider = ({
 
   function getChildren() {
     const variants = {
-      visible: { height: 'fit-content' },
-      hidden: { height: 0 },
+      visible: { height: 'fit-content', transitionEnd: { overflow: 'visible' } },
+      hidden: { height: 0, overflow: 'hidden' },
     };
 
     return (

--- a/src/hooks/use-focus-first.ts
+++ b/src/hooks/use-focus-first.ts
@@ -2,7 +2,7 @@ import { RefObject, useEffect } from 'react';
 import { FOCUSABLE_ELEMENTS_QUERY } from './use-focus-trap';
 
 /**
- * Trap accessibility focus within the ref object.
+ * Auto-focus the first focusable element (if any) within the ref object.
  *
  * @param ref a reference to an HTMLElement, attach object from `useRef` to this
  * @param active conditionally enable this hook (default: true [always enabled])


### PR DESCRIPTION
just a fix for a little bug i found while messing around, it made the dropdown cut off

- `overflow: hidden` causes absolute children to not break out
- solution: animate `overflow: hidden` and restore it on `transitionEnd` of visible
  - why `transitionEnd`? restoring it at the beginning will make it show before the animation expands to the area

**before:**
![animate-overflow-before](https://user-images.githubusercontent.com/29434693/162588693-60b2334e-d69f-430a-9652-007bdeef91e3.gif)

**after:**
![animate-overflow-after](https://user-images.githubusercontent.com/29434693/162588703-14becabd-6e11-459b-882d-1630a553a0ab.gif)

