### PR TITLE
Basic api requests and fetch decks for flashcard-decks page

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,2 @@
+ECHOSTUDY_HOME=https://echostudy.com
+ECHOSTUDY_API_URL=https://api.echostudy.com

--- a/src/helpers/api.ts
+++ b/src/helpers/api.ts
@@ -1,0 +1,1 @@
+export const ECHOSTUDY_API_URL = process.env.ECHOSTUDY_API_URL ?? 'https://api.echostudy.com';

--- a/src/hooks/api/use-cards-client.ts
+++ b/src/hooks/api/use-cards-client.ts
@@ -3,7 +3,7 @@ import { Card } from '../../models/card';
 /* eslint-disable @typescript-eslint/no-unused-vars */
 
 /**
- * Client targetting endpoints for /api/Cards
+ * Client targetting endpoints for /Cards
  */
 export function useCardsClient() {
   return {
@@ -30,27 +30,27 @@ export function useCardsClient() {
   /// queries ///
   ///////////////
 
-  // GET: /api/Cards/{id}
+  // GET: /Cards/{id}
   async function getCardById(id: number): Promise<Card> {
     throw new Error('Not implemented');
   }
 
-  // GET: /api/Cards/UserEmail={userEmail}
+  // GET: /Cards/UserEmail={userEmail}
   async function getCardsByEmail(userEmail: string): Promise<Card[]> {
     throw new Error('Not implemented');
   }
 
-  // GET: ​/api​/Cards​/User={userId}
+  // GET: ​/Cards​/User={userId}
   async function getCardsByUserId(userId: number): Promise<Card[]> {
     throw new Error('Not implemented');
   }
 
-  // GET: ​/api​/Cards​/Deck={deckId}
+  // GET: /Cards​/Deck={deckId}
   async function getCardsByDeckId(deckId: number): Promise<Card[]> {
     throw new Error('Not implemented');
   }
 
-  // GET: /api/Cards
+  // GET: /Cards
   async function getAllCards(): Promise<Card[]> {
     throw new Error('Not implemented');
   }
@@ -59,17 +59,17 @@ export function useCardsClient() {
   /// adds & updates ///
   //////////////////////
 
-  // POST: /api/Cards
+  // POST: /Cards
   async function addCard(card: Card): Promise<Card> {
     throw new Error('Not implemented');
   }
 
-  // PUT: /api/Cards/{id}
+  // PUT: /Cards/{id}
   async function updateCardById(id: number, card: Card): Promise<Card> {
     throw new Error('Not implemented');
   }
 
-  // PATCH: /api/Cards/Touch={id}&{score}
+  // PATCH: /Cards/Touch={id}&{score}
   async function updateCardScoreById(id: number, score: number): Promise<void> {
     // note: potentially might be POST in the future
     throw new Error('Not implemented');
@@ -79,22 +79,22 @@ export function useCardsClient() {
   /// deletions ///
   /////////////////
 
-  // DELETE: /api/Cards/{id}
+  // DELETE: /Cards/{id}
   async function deleteCardById(id: number): Promise<void> {
     throw new Error('Not implemented');
   }
 
-  // DELETE: /api/Cards/DeleteUserCards={userId}
+  // DELETE: /Cards/DeleteUserCards={userId}
   async function deleteCardsByUserId(userId: number): Promise<void> {
     throw new Error('Not implemented');
   }
 
-  // DELETE: ​/api​/Cards​/DeleteUserCardsByEmail={userEmail}
+  // DELETE: /Cards​/DeleteUserCardsByEmail={userEmail}
   async function deleteCardsByEmail(userEmail: string): Promise<void> {
     throw new Error('Not implemented');
   }
 
-  // DELETE: /api/Cards/DeleteDeckCards={deckId}
+  // DELETE: /Cards/DeleteDeckCards={deckId}
   async function deleteCardsByDeckId(deckId: number): Promise<void> {
     throw new Error('Not implemented');
   }

--- a/src/hooks/api/use-decks-client.ts
+++ b/src/hooks/api/use-decks-client.ts
@@ -3,7 +3,7 @@ import { Deck } from '../../models/deck';
 /* eslint-disable @typescript-eslint/no-unused-vars */
 
 /**
- * Client targetting endpoints for /api/Decks
+ * Client targetting endpoints for /Decks
  */
 export function useDecksClient() {
   return {
@@ -30,32 +30,32 @@ export function useDecksClient() {
   /// queries ///
   ///////////////
 
-  // GET: /api/Decks/{id}
+  // GET: /Decks/{id}
   async function getDeckById(id: number): Promise<Deck> {
     throw new Error('Not implemented');
   }
 
-  // GET: /api/Decks/UserEmail={userEmail}
+  // GET: /Decks/UserEmail={userEmail}
   async function getDecksByEmail(userEmail: string): Promise<Deck[]> {
     throw new Error('Not implemented');
   }
 
-  // GET: /api/Decks/User={userId}
+  // GET: /Decks/User={userId}
   async function getDecksByUserId(userId: number): Promise<Deck[]> {
     throw new Error('Not implemented');
   }
 
-  // GET: ​/api​/Decks​/DeckCategory={categoryId}
+  // GET: ​/Decks​/DeckCategory={categoryId}
   async function getDecksByCategoryId(categoryId: number): Promise<Deck[]> {
     throw new Error('Not implemented');
   }
 
-  // GET: /api/Decks
+  // GET: /Decks
   async function getAllDecks(): Promise<Deck[]> {
     throw new Error('Not implemented');
   }
 
-  // GET: /api/Decks/Public
+  // GET: /Decks/Public
   async function getPublicDecks(): Promise<Deck[]> {
     throw new Error('Not implemented');
   }
@@ -64,17 +64,17 @@ export function useDecksClient() {
   /// adds & updates ///
   //////////////////////
 
-  // POST: /api/Decks
+  // POST: /Decks
   async function addDeck(deck: Deck): Promise<Deck> {
     throw new Error('Not implemented');
   }
 
-  // PUT: /api/Decks/{id}
+  // PUT: /Decks/{id}
   async function updateDeckById(id: number, deck: Deck): Promise<void> {
     throw new Error('Not implemented');
   }
 
-  // PATCH: /api/Decks/Touch={id}
+  // PATCH: /Decks/Touch={id}
   async function touchDeckById(id: number): Promise<void> {
     // note: potentially might be POST in the future
     throw new Error('Not implemented');
@@ -84,17 +84,17 @@ export function useDecksClient() {
   /// deletions ///
   /////////////////
 
-  // DELETE: /api/Decks/{id}
+  // DELETE: /Decks/{id}
   async function deleteDeckById(id: number): Promise<void> {
     throw new Error('Not implemented');
   }
 
-  // DELETE: /api/Decks/DeleteUserDecks={userId}
+  // DELETE: /Decks/DeleteUserDecks={userId}
   async function deleteDecksByUserId(userId: number): Promise<void> {
     throw new Error('Not implemented');
   }
 
-  // DELETE: /api/Decks/DeleteUserDecksByEmail={userEmail}
+  // DELETE: /Decks/DeleteUserDecksByEmail={userEmail}
   async function deleteDecksByEmail(userEmail: string): Promise<void> {
     throw new Error('Not implemented');
   }

--- a/src/hooks/api/use-decks-client.ts
+++ b/src/hooks/api/use-decks-client.ts
@@ -1,4 +1,7 @@
 import { Deck } from '../../models/deck';
+import { useFetchWrapper } from './use-fetch-wrapper';
+import { ECHOSTUDY_API_URL } from '../../helpers/api';
+import { DeckCover } from '../../components/deck-cover/deck-cover';
 
 /* eslint-disable @typescript-eslint/no-unused-vars */
 
@@ -6,6 +9,8 @@ import { Deck } from '../../models/deck';
  * Client targetting endpoints for /Decks
  */
 export function useDecksClient() {
+  const fetchWrapper = useFetchWrapper(ECHOSTUDY_API_URL);
+
   return {
     // queries
     getDeckById,
@@ -52,12 +57,44 @@ export function useDecksClient() {
 
   // GET: /Decks
   async function getAllDecks(): Promise<Deck[]> {
-    throw new Error('Not implemented');
+    const response = await fetchWrapper.get('/Decks');
+    const decksData = JSON.parse(response);
+
+    // todo perhaps make Deck a class, and implement a fromJson
+    const decks: Deck[] = decksData.map((obj: any): Deck => {
+      return {
+        id: obj['id'],
+        title: obj['title'],
+        desc: obj['description'],
+        access: obj['access'],
+        frontLang: obj['default_flang'],
+        backLang: obj['default_blang'],
+        cards: obj['cards'],
+      };
+    });
+
+    return decks;
   }
 
   // GET: /Decks/Public
   async function getPublicDecks(): Promise<Deck[]> {
-    throw new Error('Not implemented');
+    const response = await fetchWrapper.get('/Decks/Public');
+    const decksData = JSON.parse(response);
+
+    // todo perhaps make Deck a class, and implement a fromJson
+    const decks: Deck[] = decksData.map((obj: any): Deck => {
+      return {
+        id: obj['id'],
+        title: obj['title'],
+        desc: obj['description'],
+        access: obj['access'],
+        frontLang: obj['default_flang'],
+        backLang: obj['default_blang'],
+        cards: obj['cards'],
+      };
+    });
+
+    return decks;
   }
 
   //////////////////////

--- a/src/hooks/api/use-decks-client.ts
+++ b/src/hooks/api/use-decks-client.ts
@@ -57,8 +57,7 @@ export function useDecksClient() {
 
   // GET: /Decks
   async function getAllDecks(): Promise<Deck[]> {
-    const response = await fetchWrapper.get('/Decks');
-    const decksData = JSON.parse(response);
+    const decksData = await fetchWrapper.get('/Decks');
 
     // todo perhaps make Deck a class, and implement a fromJson
     const decks: Deck[] = decksData.map((obj: any): Deck => {
@@ -78,8 +77,7 @@ export function useDecksClient() {
 
   // GET: /Decks/Public
   async function getPublicDecks(): Promise<Deck[]> {
-    const response = await fetchWrapper.get('/Decks/Public');
-    const decksData = JSON.parse(response);
+    const decksData = await fetchWrapper.get('/Decks/Public');
 
     // todo perhaps make Deck a class, and implement a fromJson
     const decks: Deck[] = decksData.map((obj: any): Deck => {

--- a/src/hooks/api/use-decks-client.ts
+++ b/src/hooks/api/use-decks-client.ts
@@ -1,8 +1,8 @@
 import { Deck } from '../../models/deck';
 import { useFetchWrapper } from './use-fetch-wrapper';
 import { ECHOSTUDY_API_URL } from '../../helpers/api';
-import { DeckCover } from '../../components/deck-cover/deck-cover';
 
+/* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/no-unused-vars */
 
 /**
@@ -62,12 +62,14 @@ export function useDecksClient() {
     // todo perhaps make Deck a class, and implement a fromJson
     const decks: Deck[] = decksData.map((obj: any): Deck => {
       return {
-        id: obj['id'],
-        title: obj['title'],
-        desc: obj['description'],
-        access: obj['access'],
-        frontLang: obj['default_flang'],
-        backLang: obj['default_blang'],
+        metaData: {
+          id: obj['id'],
+          title: obj['title'],
+          desc: obj['description'],
+          access: obj['access'],
+          frontLang: obj['default_flang'],
+          backLang: obj['default_blang'],
+        },
         cards: obj['cards'],
       };
     });
@@ -82,12 +84,14 @@ export function useDecksClient() {
     // todo perhaps make Deck a class, and implement a fromJson
     const decks: Deck[] = decksData.map((obj: any): Deck => {
       return {
-        id: obj['id'],
-        title: obj['title'],
-        desc: obj['description'],
-        access: obj['access'],
-        frontLang: obj['default_flang'],
-        backLang: obj['default_blang'],
+        metaData: {
+          id: obj['id'],
+          title: obj['title'],
+          desc: obj['description'],
+          access: obj['access'],
+          frontLang: obj['default_flang'],
+          backLang: obj['default_blang'],
+        },
         cards: obj['cards'],
       };
     });

--- a/src/hooks/api/use-fetch-wrapper.ts
+++ b/src/hooks/api/use-fetch-wrapper.ts
@@ -1,7 +1,9 @@
 /**
  * fetch() wrapper with useful helper functions
+ *
+ * @param prependApiUrl url to prepend to all requests
  */
-export function useFetchWrapper() {
+export function useFetchWrapper(prependApiUrl?: string) {
   // https://jasonwatmore.com/post/2021/09/07/react-recoil-jwt-authentication-tutorial-and-example
   /* eslint-disable @typescript-eslint/no-unused-vars */
 
@@ -13,17 +15,37 @@ export function useFetchWrapper() {
   };
 
   function request(method: string) {
-    // todo: fetch and then handleResponse
-    throw new Error('Not implemented');
+    return async function (url: string, body?: object) {
+      // only include header if `body` is non-empty
+      const contentTypeHeader = body ? { 'Content-Type': 'application/json' } : undefined;
+      const resolvedUrl = prependApiUrl ? prependApiUrl + url : url;
+
+      const response = await fetch(resolvedUrl, {
+        method: method,
+        headers: { ...contentTypeHeader }, // todo: use auth header which includes JWT
+        body: body && JSON.stringify(body),
+      });
+
+      return await handleResponse(response);
+    };
   }
 
   ////////////////////////
   /// helper functions ///
   ////////////////////////
 
-  function handleResponse(response: Response) {
-    // todo: handle response by converting to text()
-    throw new Error('Not implemented');
+  async function handleResponse(response: Response) {
+    const text = await response.text();
+    const data = text && JSON.parse(text);
+
+    if (!response.ok) {
+      // todo: handle 401/403 for user auth, verify JWT token, if not redirect to /login
+      const error = data?.message ?? response.statusText;
+      console.error(error);
+      return Promise.reject(error);
+    }
+
+    return data;
   }
 
   function authHeader(url: string): Record<string, string> {

--- a/src/hooks/api/use-fetch-wrapper.ts
+++ b/src/hooks/api/use-fetch-wrapper.ts
@@ -35,8 +35,7 @@ export function useFetchWrapper(prependApiUrl?: string) {
   ////////////////////////
 
   async function handleResponse(response: Response) {
-    const text = await response.text();
-    const data = text && JSON.parse(text);
+    const data = await response.json();
 
     if (!response.ok) {
       // todo: handle 401/403 for user auth, verify JWT token, if not redirect to /login

--- a/src/pages/decks/flashcard-decks.tsx
+++ b/src/pages/decks/flashcard-decks.tsx
@@ -1,10 +1,12 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { DeckCover } from '../../components/deck-cover/deck-cover';
 import { DropDownOption } from '../../components/drop-down-options/drop-down-options';
 import { DropDown } from '../../components/drop-down/drop-down';
 import { noop } from '../../helpers/func';
+import { useDecksClient } from '../../hooks/api/use-decks-client';
+import { useFetchWrapper } from '../../hooks/api/use-fetch-wrapper';
 import { Deck } from '../../models/deck';
 import {
   testEnglishDeck,
@@ -24,7 +26,7 @@ const addNewDeckEntity: Deck = {
   cards: [],
 };
 let id = 0;
-const decks = [
+const testDecks = [
   testEnglishDeck(id++),
   testJapaneseVerbsDeck(id++),
   testNPTEPartNumberDeck(id++, 1),
@@ -38,7 +40,15 @@ const sortRuleOptions = sortRules.map((item): DropDownOption => ({ id: item, val
 
 export const FlashcardDecksPage = () => {
   const navigate = useNavigate();
+  const decksClient = useDecksClient();
+
+  const [decks, setDecks] = useState(testDecks);
   const [sortOption, setSortOption] = useState(sortRules[1]);
+
+  // fetch flashcard decks on load
+  useEffect(() => {
+    fetchDecksAndRefresh();
+  }, []);
 
   return (
     <div className="pg-flashcard-decks">
@@ -78,5 +88,11 @@ export const FlashcardDecksPage = () => {
   function onAddDeckClicked() {
     // todo: maybe different route without any params (:deckId) since there is no 'deck' yet
     navigate('/deck-editor/0');
+  }
+
+  async function fetchDecksAndRefresh() {
+    // todo: should get deck by user id in the future
+    const fetchedDecks = await decksClient.getAllDecks();
+    setDecks(fetchedDecks);
   }
 };


### PR DESCRIPTION
- Implement fetch wrapper with basic functionality, no JWT/auth tokens yet
- Changes to `useDeckClient` --> implement `getAllDecks`, `getPublicDecks`
---
- Cannot actually hit the endpoints in dev environment due to CORS
  - To test, I copied the response from the endpoint
  - We probably want to fix CORS on the backend and test if it actually works before merging
---
![fetched-decks-from-api](https://user-images.githubusercontent.com/29434693/163317747-550853c1-bb07-4963-b4e7-6fab7dd13126.png)

