### PR TITLE
added useDeckEditor hook

### DIFF
--- a/src/components/deck-cover/deck-cover.tsx
+++ b/src/components/deck-cover/deck-cover.tsx
@@ -39,15 +39,15 @@ export const DeckCover = ({
   }
 
   function getCoverFront() {
-    return <div className="cover-front">{deck.title}</div>;
+    return <div className="cover-front">{deck.metaData.title}</div>;
   }
 
   function getCoverBack() {
     const percentStudied = 1;
     return (
       <div className="cover-back">
-        <label>{deck.title}</label>
-        <p>{deck.desc}</p>
+        <label>{deck.metaData.title}</label>
+        <p>{deck.metaData.desc}</p>
         <div className="button-strip">
           <div className="progress-bar">
             <ProgressBar percent={percentStudied} label={`${percentStudied}% studied`} />

--- a/src/components/flashcard-set/flashcard-set.tsx
+++ b/src/components/flashcard-set/flashcard-set.tsx
@@ -9,19 +9,23 @@ interface FlashcardSetProps {
   variant?: 'readonly' | 'editable';
   className?: string;
   cards: Card[];
-  onCardsChange?: (cards: Card[]) => void;
+  onDeleteCardClick?: (card: Card) => void;
+  onCardReorder?: (cards: Card[]) => void;
+  onCardChange?: (card: Card) => void;
 }
 
 export const FlashcardSet = ({
   variant = 'editable',
   className = '',
   cards,
-  onCardsChange,
+  onCardReorder,
+  onDeleteCardClick,
+  onCardChange,
 }: FlashcardSetProps) => {
   const [activeCard, setActiveCard] = useState('');
   return (
     <div className={`c-flashcard-set ${className}`}>
-      <Reorder.Group axis="y" values={cards} onReorder={handleReorder}>
+      <Reorder.Group axis="y" values={cards} onReorder={handleCardReorder}>
         {getCards()}
       </Reorder.Group>
     </div>
@@ -30,16 +34,16 @@ export const FlashcardSet = ({
   function getCards() {
     return cards.map((card, index) => {
       return (
-        <Reorder.Item key={card.id ?? card.key} value={card}>
+        <Reorder.Item key={card.key} value={card}>
           <Flashcard
             card={card}
             index={index + 1}
             variant={getCardVariant(card.key)}
             onFocus={() => setActiveCard(card.key)}
-            onCardChange={(c) => handleCardChange(c, index)}
+            onCardChange={(card) => variant === 'editable' && onCardChange?.(card)}
             onDownClick={() => handleDownClick(index)}
             onUpClick={() => handleUpClick(index)}
-            onRemoveClick={() => handleRemoveClick(index)}
+            onRemoveClick={() => variant === 'editable' && onDeleteCardClick?.(card)}
           />
         </Reorder.Item>
       );
@@ -51,43 +55,27 @@ export const FlashcardSet = ({
     return activeCard === cardKey ? 'active' : 'inactive';
   }
 
-  function handleRemoveClick(index: number) {
-    const newCards = [...cards];
-    newCards.splice(index, 1);
-    handleCardsChange(newCards);
-  }
-
   function handleUpClick(index: number) {
     const newCards = [...cards];
     newCards[index] = newCards.splice(index - 1, 1, cards[index])[0];
-    handleCardsChange(newCards);
+    handleCardReorder(newCards);
   }
 
   function handleDownClick(index: number) {
     if (index === cards.length - 1) {
       const newCards = [...cards];
       const [lastCard] = newCards.splice(index, 1);
-      handleCardsChange([lastCard, ...newCards]);
+      handleCardReorder([lastCard, ...newCards]);
     } else {
       const newCards = [...cards];
       newCards[index] = newCards.splice(index + 1, 1, cards[index])[0];
-      handleCardsChange(newCards);
+      handleCardReorder(newCards);
     }
   }
 
-  function handleCardChange(newCard: Card, index: number) {
-    const newCards = [...cards];
-    newCards[index] = newCard;
-    handleCardsChange(newCards);
-  }
-
-  function handleReorder(newCards: Card[]) {
-    handleCardsChange(newCards);
-  }
-
-  function handleCardsChange(newCards: Card[]) {
+  function handleCardReorder(newCards: Card[]) {
     if (variant === 'editable') {
-      onCardsChange?.(newCards);
+      onCardReorder?.(newCards);
     }
   }
 };

--- a/src/components/header/header.tsx
+++ b/src/components/header/header.tsx
@@ -28,7 +28,7 @@ export const Header = ({ decks }: HeaderProps) => {
   );
 
   function getDeckOptions() {
-    return decks.map((deck) => ({ id: deck.id.toString(), value: deck.title }));
+    return decks.map((deck) => ({ id: deck.metaData.id.toString(), value: deck.metaData.title }));
   }
 
   function handleSignUpClick() {

--- a/src/hooks/use-deck-editor.ts
+++ b/src/hooks/use-deck-editor.ts
@@ -1,0 +1,193 @@
+import { useReducer } from 'react';
+import { Card, createNewCard } from '../models/card';
+import { Deck, DeckMetaData } from '../models/deck';
+
+type CardMap = { [id: string]: Card };
+
+interface DeckEditorState {
+  deck: Deck;
+  hasUnsavedChanges: boolean;
+}
+
+interface DeckEditorMethods {
+  save: () => void;
+  discardChanges: () => void;
+  addCard: () => void;
+  deleteCard: (card: Card) => void;
+  updateCard: (card: Card) => void;
+  updateMetaData: (metaData: DeckMetaData) => void;
+  reorderCards: (cards: Card[]) => void;
+}
+
+interface DeckReducerState {
+  currentDeck: Deck;
+  savedDeck: Deck;
+  hasUnsavedChanges: boolean;
+  addedCards: CardMap;
+  deletedCards: CardMap;
+  updatedCards: CardMap;
+}
+
+interface DeckReducerDispatch {
+  type: DECK_REDUCER_TYPE;
+  card?: Card;
+  metaData?: DeckMetaData;
+  cards?: Card[];
+}
+
+const enum DECK_REDUCER_TYPE {
+  SAVE = 'SAVE',
+  DISCARD_CHANGES = 'DISCARD_CHANGES',
+  UPDATE_META_DATA = 'UPDATE_META_DATA',
+  ADD_CARD = 'ADD_CARD',
+  DELETE_CARD = 'DELETE_CARD',
+  UPDATE_CARD = 'UPDATE_CARD',
+  REORDER_CARDS = 'REORDER_CARDS',
+}
+
+export const useDeckEditor = (deck: Deck): [state: DeckEditorState, methods: DeckEditorMethods] => {
+  const [state, dispatch] = useReducer(deckEditorReducer, {
+    currentDeck: deck,
+    savedDeck: deck,
+    hasUnsavedChanges: false,
+    addedCards: {},
+    updatedCards: {},
+    deletedCards: {},
+  });
+
+  function save() {
+    dispatch({ type: DECK_REDUCER_TYPE.SAVE });
+  }
+  function discardChanges() {
+    dispatch({ type: DECK_REDUCER_TYPE.DISCARD_CHANGES });
+  }
+  function updateMetaData(metaData: DeckMetaData) {
+    dispatch({ type: DECK_REDUCER_TYPE.UPDATE_META_DATA, metaData });
+  }
+  function addCard() {
+    dispatch({ type: DECK_REDUCER_TYPE.ADD_CARD });
+  }
+  function deleteCard(card: Card) {
+    dispatch({ type: DECK_REDUCER_TYPE.DELETE_CARD, card });
+  }
+  function updateCard(card: Card) {
+    dispatch({ type: DECK_REDUCER_TYPE.UPDATE_CARD, card });
+  }
+  function reorderCards(cards: Card[]) {
+    dispatch({ type: DECK_REDUCER_TYPE.REORDER_CARDS, cards });
+  }
+
+  return [
+    { deck: state.currentDeck, hasUnsavedChanges: state.hasUnsavedChanges },
+    { addCard, deleteCard, updateCard, updateMetaData, save, discardChanges, reorderCards },
+  ];
+};
+
+function deckEditorReducer(state: DeckReducerState, action: DeckReducerDispatch): DeckReducerState {
+  const { currentDeck, savedDeck, addedCards, deletedCards, updatedCards } = state;
+  const { type, card, cards, metaData } = action;
+
+  switch (type) {
+    case DECK_REDUCER_TYPE.ADD_CARD:
+      const newCard = createNewCard();
+      return {
+        ...state,
+        currentDeck: addCardToDeck(newCard, currentDeck),
+        addedCards: addCardToMap(newCard, addedCards),
+        hasUnsavedChanges: true,
+      };
+
+    case DECK_REDUCER_TYPE.DELETE_CARD:
+      if (card === undefined) {
+        throw new Error('action.card must not be undefined');
+      }
+      return {
+        ...state,
+        addedCards: removeCardFromMap(card, addedCards),
+        updatedCards: removeCardFromMap(card, updatedCards),
+        deletedCards: addCardToMap(card, deletedCards),
+        currentDeck: removeCardFromDeck(card, currentDeck),
+        hasUnsavedChanges: true,
+      };
+
+    case DECK_REDUCER_TYPE.SAVE:
+      // Todo: make the API calls
+      // Todo: update the id's of new cards
+      return {
+        ...state,
+        savedDeck: currentDeck,
+        addedCards: {},
+        deletedCards: {},
+        updatedCards: {},
+        hasUnsavedChanges: false,
+      };
+
+    case DECK_REDUCER_TYPE.DISCARD_CHANGES:
+      return {
+        ...state,
+        currentDeck: savedDeck,
+        addedCards: {},
+        deletedCards: {},
+        updatedCards: {},
+        hasUnsavedChanges: false,
+      };
+
+    case DECK_REDUCER_TYPE.UPDATE_META_DATA:
+      if (metaData === undefined) throw new Error('action.metaData must not be undefined');
+
+      return { ...state, currentDeck: { ...currentDeck, metaData }, hasUnsavedChanges: true };
+
+    case DECK_REDUCER_TYPE.UPDATE_CARD:
+      if (card === undefined) throw new Error('action.card must not be undefined');
+
+      return {
+        ...state,
+        addedCards: card.id ? addCardToMap(card, addedCards) : addedCards,
+        updatedCards: !card.id ? addCardToMap(card, updatedCards) : updatedCards,
+        hasUnsavedChanges: true,
+        currentDeck: updateCardInDeck(card, currentDeck),
+      };
+
+    case DECK_REDUCER_TYPE.REORDER_CARDS:
+      if (cards === undefined) throw new Error('action.cards must not be undefined');
+
+      // Todo: find reordered card
+      // Todo: update reordered card
+      // Todo: add card to updatedCards map
+      return {
+        ...state,
+        currentDeck: { ...currentDeck, cards: cards },
+        hasUnsavedChanges: true,
+      };
+    default:
+      throw new Error('unrecognized dispatch action type');
+  }
+}
+
+function addCardToMap(card: Card, map: CardMap) {
+  return { ...map, [card.key]: card };
+}
+
+function removeCardFromMap(card: Card, map: CardMap) {
+  const newMap = { ...map };
+  delete newMap[card.key];
+  return newMap;
+}
+
+function removeCardFromDeck(card: Card, deck: Deck) {
+  const cardIndex = deck.cards.findIndex((deckCard) => card.key === deckCard.key);
+  const newCards = [...deck.cards];
+  newCards.splice(cardIndex, 1);
+  return { ...deck, cards: newCards };
+}
+
+function updateCardInDeck(card: Card, deck: Deck) {
+  const cardIndex = deck.cards.findIndex((deckCard) => card.key === deckCard.key);
+  const newCards = [...deck.cards];
+  newCards[cardIndex] = card;
+  return { ...deck, cards: newCards };
+}
+
+function addCardToDeck(card: Card, deck: Deck) {
+  return { ...deck, cards: [card, ...deck.cards] };
+}

--- a/src/hooks/use-deck-editor.ts
+++ b/src/hooks/use-deck-editor.ts
@@ -142,8 +142,8 @@ function deckEditorReducer(state: DeckReducerState, action: DeckReducerDispatch)
 
       return {
         ...state,
-        addedCards: card.id ? addCardToMap(card, addedCards) : addedCards,
-        updatedCards: !card.id ? addCardToMap(card, updatedCards) : updatedCards,
+        addedCards: !card.id ? addCardToMap(card, addedCards) : addedCards,
+        updatedCards: card.id ? addCardToMap(card, updatedCards) : updatedCards,
         hasUnsavedChanges: true,
         currentDeck: updateCardInDeck(card, currentDeck),
       };

--- a/src/models/deck.ts
+++ b/src/models/deck.ts
@@ -6,12 +6,27 @@ export type Language = typeof DeckLanguages[number];
 
 export type Access = 'Public' | 'Private';
 
-export interface Deck {
+export interface DeckMetaData {
   id: number;
   title: string;
   desc: string;
   access: Access;
   frontLang: Language;
   backLang: Language;
+}
+export interface Deck {
+  metaData: DeckMetaData;
   cards: Card[];
+}
+
+export function createNewDeck(): Deck {
+  const metaData: DeckMetaData = {
+    id: -1,
+    title: '',
+    desc: '',
+    access: 'Private',
+    frontLang: 'English',
+    backLang: 'English',
+  };
+  return { cards: [], metaData };
 }

--- a/src/models/mock/deck.mock.ts
+++ b/src/models/mock/deck.mock.ts
@@ -1,31 +1,37 @@
-import { Deck } from '../deck';
+import { Deck, DeckMetaData } from '../deck';
 
-export const testEnglishDeck = (id: number): Deck => ({
-  id: id,
-  title: 'English 101',
-  desc: 'The course concentrates primarily on expository, effective composing, revising, and editing strategies.',
-  access: 'Private',
-  frontLang: 'English',
-  backLang: 'English',
-  cards: [],
-});
+export const testEnglishDeck = (id: number): Deck => {
+  const metaData: DeckMetaData = {
+    id: id,
+    title: 'English 101',
+    desc: 'The course concentrates primarily on expository, effective composing, revising, and editing strategies.',
+    access: 'Private',
+    frontLang: 'English',
+    backLang: 'English',
+  };
+  return { metaData, cards: [] };
+};
 
-export const testJapaneseVerbsDeck = (id: number): Deck => ({
-  id: id,
-  title: 'Japanese Verbs',
-  desc: 'The course concentrates primarily on Japanese verbs.',
-  access: 'Private',
-  frontLang: 'English',
-  backLang: 'English',
-  cards: [],
-});
+export const testJapaneseVerbsDeck = (id: number): Deck => {
+  const metaData: DeckMetaData = {
+    id: id,
+    title: 'Japanese Verbs',
+    desc: 'The course concentrates primarily on Japanese verbs.',
+    access: 'Private',
+    frontLang: 'English',
+    backLang: 'English',
+  };
+  return { metaData, cards: [] };
+};
 
-export const testNPTEPartNumberDeck = (id: number, partNumber: number): Deck => ({
-  id: id,
-  title: `NPTE Part ${partNumber}`,
-  desc: 'Taking the National Physical Therapy Examination (NPTE) is an important step toward receiving your physical therapist (PT) or physical therapist assistant (PTA) license.',
-  access: 'Private',
-  frontLang: 'English',
-  backLang: 'English',
-  cards: [],
-});
+export const testNPTEPartNumberDeck = (id: number, partNumber: number): Deck => {
+  const metaData: DeckMetaData = {
+    id: id,
+    title: `NPTE Part ${partNumber}`,
+    desc: 'Taking the National Physical Therapy Examination (NPTE) is an important step toward receiving your physical therapist (PT) or physical therapist assistant (PTA) license.',
+    access: 'Private',
+    frontLang: 'English',
+    backLang: 'English',
+  };
+  return { metaData, cards: [] };
+};

--- a/src/pages/deck-editor/deck-editor.test.tsx
+++ b/src/pages/deck-editor/deck-editor.test.tsx
@@ -1,0 +1,81 @@
+import React from 'react';
+import { render, screen, waitForElementToBeRemoved } from '@testing-library/react';
+import { DeckEditorPage } from './deck-editor';
+import userEvent from '@testing-library/user-event';
+import Router from 'react-router-dom';
+
+const TEST_LABEL = 'TEST_INITIAL_TEXT';
+
+// Todo: mock the the fetch module
+
+const mockedUseNavigate = jest.fn();
+const mockedUseParams = jest.fn().mockReturnValue(() => ({ deckId: -1 }));
+
+jest.mock('react-router-dom', () => ({
+  ...(jest.requireActual('react-router-dom') as any),
+  useNavigate: () => mockedUseNavigate,
+  useParams: () => mockedUseParams,
+}));
+
+jest.mock('../../hooks/use-prompt');
+
+describe('DeckEditor', () => {
+  beforeEach(() => {
+    // setup portal element for modal to render on
+    document.body.innerHTML = `<div id="portal"></div>`;
+
+    // Todo: update deckId when fetch is fixed
+    jest.spyOn(Router, 'useParams').mockReturnValue({ deckId: '' });
+  });
+
+  it('should render correctly with default props', () => {
+    render(<DeckEditorPage label={TEST_LABEL} />);
+    expect(screen.queryByText(TEST_LABEL)).toBeInTheDocument();
+    expect(screen.queryByText('save')).toBeInTheDocument();
+    expect(screen.queryByText('new card')).toBeInTheDocument();
+    expect(screen.queryByText('discard changes')).not.toBeInTheDocument();
+    expect(
+      screen.queryByText('you currently have no cards. click "+ new card" to get started')
+    ).toBeInTheDocument();
+  });
+
+  it('should add a new card on click', () => {
+    render(<DeckEditorPage label={TEST_LABEL} />);
+
+    userEvent.click(screen.getByText('new card'));
+
+    expect(screen.queryByPlaceholderText('add term')).toBeInTheDocument();
+    expect(screen.queryByPlaceholderText('add definition')).toBeInTheDocument();
+  });
+
+  it('should display discard changes button when deck is not saved', () => {
+    render(<DeckEditorPage label={TEST_LABEL} />);
+    userEvent.click(screen.getByText('new card'));
+    expect(screen.queryByText('discard changes')).toBeInTheDocument();
+  });
+
+  it('should call discard changes on discard changes click', () => {
+    render(<DeckEditorPage label={TEST_LABEL} />);
+
+    userEvent.click(screen.getByText('new card'));
+    expect(screen.queryByPlaceholderText('add term')).toBeInTheDocument();
+    expect(screen.queryByPlaceholderText('add definition')).toBeInTheDocument();
+
+    userEvent.click(screen.getByText('discard changes'));
+
+    expect(screen.queryByPlaceholderText('add term')).not.toBeInTheDocument();
+    expect(screen.queryByPlaceholderText('add definition')).not.toBeInTheDocument();
+  });
+
+  it('should hide discard changes button on save', async () => {
+    render(<DeckEditorPage label={TEST_LABEL} />);
+
+    userEvent.click(screen.getByText('new card'));
+
+    expect(screen.getByText('discard changes')).toBeInTheDocument();
+
+    userEvent.click(screen.getByText('save'));
+
+    await waitForElementToBeRemoved(() => screen.queryByText('discard changes'));
+  });
+});

--- a/src/pages/deck-editor/meta-data-editor/meta-data-editor.test.tsx
+++ b/src/pages/deck-editor/meta-data-editor/meta-data-editor.test.tsx
@@ -12,18 +12,22 @@ describe('MetaDataEditor', () => {
   });
 
   it('should render correctly with default props', () => {
-    const testDeck = testEnglishDeck(1);
-    render(<MetaDataEditor deck={testDeck} onDeckChange={noop} onDeleteClick={noop} />);
+    const { metaData } = testEnglishDeck(1);
+    render(
+      <MetaDataEditor deckMetaData={metaData} onDeckMetaDataChange={noop} onDeleteClick={noop} />
+    );
     expect(screen.queryByText('import cards')).toBeInTheDocument();
     expect(screen.queryByText('export deck')).toBeInTheDocument();
     expect(screen.queryByText('advanced settings')).toBeInTheDocument();
-    expect(screen.queryByDisplayValue(testDeck.title)).toBeInTheDocument();
-    expect(screen.queryByDisplayValue(testDeck.desc)).toBeInTheDocument();
+    expect(screen.queryByDisplayValue(metaData.title)).toBeInTheDocument();
+    expect(screen.queryByDisplayValue(metaData.desc)).toBeInTheDocument();
   });
 
   it('should hide advanced settings until dropdown is clicked', () => {
-    const testDeck = testEnglishDeck(1);
-    render(<MetaDataEditor deck={testDeck} onDeckChange={noop} onDeleteClick={noop} />);
+    const { metaData } = testEnglishDeck(1);
+    render(
+      <MetaDataEditor deckMetaData={metaData} onDeckMetaDataChange={noop} onDeleteClick={noop} />
+    );
 
     expect(screen.queryByText('default term language')).not.toBeInTheDocument();
     expect(screen.queryByText('default definition language')).not.toBeInTheDocument();
@@ -35,18 +39,28 @@ describe('MetaDataEditor', () => {
   });
 
   it('should call onDeckChange when meta data is changed', () => {
-    const testDeck = testEnglishDeck(1);
+    const { metaData } = testEnglishDeck(1);
     const mockOnDeckChange = jest.fn();
-    render(<MetaDataEditor deck={testDeck} onDeckChange={mockOnDeckChange} onDeleteClick={noop} />);
-    userEvent.type(screen.getByDisplayValue(testDeck.title), 't');
+    render(
+      <MetaDataEditor
+        deckMetaData={metaData}
+        onDeckMetaDataChange={mockOnDeckChange}
+        onDeleteClick={noop}
+      />
+    );
+    userEvent.type(screen.getByDisplayValue(metaData.title), 't');
     expect(mockOnDeckChange).toHaveBeenCalled();
   });
 
   it('should call onDeckChange when meta data is changed', () => {
-    const testDeck = testEnglishDeck(1);
+    const { metaData } = testEnglishDeck(1);
     const mockOnDeleteClick = jest.fn();
     render(
-      <MetaDataEditor deck={testDeck} onDeckChange={noop} onDeleteClick={mockOnDeleteClick} />
+      <MetaDataEditor
+        deckMetaData={metaData}
+        onDeckMetaDataChange={noop}
+        onDeleteClick={mockOnDeleteClick}
+      />
     );
     userEvent.click(screen.getByText('advanced settings'));
     userEvent.click(screen.getByText('delete deck'));

--- a/src/pages/deck-editor/meta-data-editor/meta-data-editor.tsx
+++ b/src/pages/deck-editor/meta-data-editor/meta-data-editor.tsx
@@ -1,6 +1,6 @@
 import './meta-data-editor.scss';
 import React, { useState } from 'react';
-import { Deck, DeckLanguages, Language } from '../../../models/deck';
+import { DeckLanguages, DeckMetaData, Language } from '../../../models/deck';
 import { Button } from '../../../components/button/button';
 import { TextBox } from '../../../components/text-box/text-box';
 import { BubbleDivider } from '../../../components/bubble-divider/bubble-divider';
@@ -10,12 +10,16 @@ import { PopupModal } from '../../../components/popup-modal/popup-modal';
 import { DropDownOption } from '../../../components/drop-down-options/drop-down-options';
 
 interface DeckEditorProps {
-  deck: Deck;
-  onDeckChange: (deck: Deck) => void;
+  deckMetaData: DeckMetaData;
+  onDeckMetaDataChange: (metaData: DeckMetaData) => void;
   onDeleteClick: (event: React.MouseEvent) => void;
 }
 
-export const MetaDataEditor = ({ deck, onDeckChange, onDeleteClick }: DeckEditorProps) => {
+export const MetaDataEditor = ({
+  deckMetaData,
+  onDeckMetaDataChange,
+  onDeleteClick,
+}: DeckEditorProps) => {
   const [showImportModal, setShowImportModal] = useState(false);
 
   return (
@@ -24,7 +28,7 @@ export const MetaDataEditor = ({ deck, onDeckChange, onDeleteClick }: DeckEditor
         <TextBox
           variant="dark"
           onChange={handleDeckTitleChange}
-          value={deck.title}
+          value={deckMetaData.title}
           label="title"
           placeholder="add a title..."
         />
@@ -35,7 +39,7 @@ export const MetaDataEditor = ({ deck, onDeckChange, onDeleteClick }: DeckEditor
           label="description"
           variant="dark"
           placeholder="add a description"
-          value={deck.desc}
+          value={deckMetaData.desc}
           onChange={handleDeckDescChange}
         />
         <Button onClick={handleImportClick} size="medium">
@@ -55,14 +59,14 @@ export const MetaDataEditor = ({ deck, onDeckChange, onDeleteClick }: DeckEditor
         <div className="advanced-settings">
           <DropDown
             label="default term language"
-            buttonLabel={deck.frontLang}
+            buttonLabel={deckMetaData.frontLang}
             options={getLanguages()}
             onOptionSelect={handleFrontLanguageSelect}
           />
 
           <DropDown
             label="default definition language"
-            buttonLabel={deck.backLang}
+            buttonLabel={deckMetaData.backLang}
             options={getLanguages()}
             onOptionSelect={handleBackLanguageSelect}
           />
@@ -93,12 +97,12 @@ export const MetaDataEditor = ({ deck, onDeckChange, onDeleteClick }: DeckEditor
 
   function handleFrontLanguageSelect(option: DropDownOption) {
     const frontLang = option.value as Language;
-    onDeckChange({ ...deck, frontLang });
+    onDeckMetaDataChange({ ...deckMetaData, frontLang });
   }
 
   function handleBackLanguageSelect(option: DropDownOption) {
     const backLang = option.value as Language;
-    onDeckChange({ ...deck, backLang });
+    onDeckMetaDataChange({ ...deckMetaData, backLang });
   }
 
   function getLanguages(): DropDownOption[] {
@@ -106,11 +110,11 @@ export const MetaDataEditor = ({ deck, onDeckChange, onDeleteClick }: DeckEditor
   }
 
   function handleDeckTitleChange(title: string) {
-    onDeckChange({ ...deck, title });
+    onDeckMetaDataChange({ ...deckMetaData, title });
   }
 
   function handleDeckDescChange(desc: string) {
-    onDeckChange({ ...deck, desc });
+    onDeckMetaDataChange({ ...deckMetaData, desc });
   }
 
   function handleImportClick() {

--- a/src/pages/decks/flashcard-decks.tsx
+++ b/src/pages/decks/flashcard-decks.tsx
@@ -5,7 +5,7 @@ import { DeckCover } from '../../components/deck-cover/deck-cover';
 import { DropDownOption } from '../../components/drop-down-options/drop-down-options';
 import { DropDown } from '../../components/drop-down/drop-down';
 import { noop } from '../../helpers/func';
-import { Deck } from '../../models/deck';
+import { createNewDeck, Deck } from '../../models/deck';
 import {
   testEnglishDeck,
   testJapaneseVerbsDeck,
@@ -14,15 +14,9 @@ import {
 import './flashcard-decks.scss';
 
 // (+ add new deck) and (all decks)
-const addNewDeckEntity: Deck = {
-  id: -1,
-  title: '+ add new deck',
-  desc: '',
-  access: 'Private',
-  frontLang: 'English',
-  backLang: 'English',
-  cards: [],
-};
+const addNewDeckEntity: Deck = createNewDeck();
+addNewDeckEntity.metaData.title = '+ add new deck';
+
 let id = 0;
 const decks = [
   testEnglishDeck(id++),
@@ -71,7 +65,7 @@ export const FlashcardDecksPage = () => {
 
   function getDeckCovers() {
     return decks.map((deck) => (
-      <DeckCover key={deck.id} deck={deck} onStudyClick={noop} onEditClick={noop} />
+      <DeckCover key={deck.metaData.id} deck={deck} onStudyClick={noop} onEditClick={noop} />
     ));
   }
 


### PR DESCRIPTION
summary of changes: 

- combined all state changes in `DeckEditor` into a `useReducer`
- created a custom hook to wrap calls and state of new `useReducer`
  - now business logic and bookkeeping are in an isolated module
-  added testing to `DeckEditor`
  - additional testing is needed
    - fetching deck
    - deleting deck
    - saving deck
  - modified `Deck` to have `DeckMetaData` as a member