### PR TITLE
added loading icons

### DIFF
--- a/src/assets/icons/loading-icon/loading-icon.scss
+++ b/src/assets/icons/loading-icon/loading-icon.scss
@@ -3,6 +3,7 @@
 
 $color: $light-blue;
 
+// loading icon taken from https://loading.io/css/
 .c-loading-icon {
   display: inline-block;
   position: relative;

--- a/src/assets/icons/loading-icon/loading-icon.scss
+++ b/src/assets/icons/loading-icon/loading-icon.scss
@@ -1,0 +1,66 @@
+@import '../../colors';
+@import '../../styles';
+
+$color: $light-blue;
+
+.c-loading-icon {
+  display: inline-block;
+  position: relative;
+  width: 40px;
+  height: 40px;
+
+  &.medium {
+    width: 80px;
+    height: 80px;
+
+    div {
+      width: 64px;
+      height: 64px;
+      margin: 8px;
+      border-width: 8px;
+    }
+  }
+
+  &.large {
+    width: 160px;
+    height: 160px;
+    div {
+      width: 124px;
+      height: 124px;
+      margin: 16px;
+      border-width: 16px;
+    }
+  }
+
+  div {
+    box-sizing: border-box;
+    display: block;
+    position: absolute;
+    width: 32px;
+    height: 32px;
+    margin: 4px;
+    border: 4px solid $color;
+    border-radius: 50%;
+    animation: c-loading-icon 1.2s cubic-bezier(0.5, 0, 0.5, 1) infinite;
+    border-color: $color transparent transparent transparent;
+
+    &:nth-child(1) {
+      animation-delay: -0.45s;
+    }
+    &:nth-child(2) {
+      animation-delay: -0.3s;
+    }
+    &:nth-child(3) {
+      animation-delay: -0.15s;
+    }
+  }
+}
+
+@keyframes c-loading-icon {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}

--- a/src/assets/icons/loading-icon/loading-icon.tsx
+++ b/src/assets/icons/loading-icon/loading-icon.tsx
@@ -1,0 +1,26 @@
+import './loading-icon.scss';
+import React from 'react';
+import { Fade } from '../../../animations/fade';
+
+interface LoadingIconProps {
+  className?: string;
+  size?: 'small' | 'medium' | 'large';
+  fadeIn?: boolean;
+}
+
+export const LoadingIcon = ({
+  className = '',
+  size = 'small',
+  fadeIn = true,
+}: LoadingIconProps) => {
+  return (
+    <Fade fadeIn={fadeIn}>
+      <div className={`c-loading-icon ${size} ${className}`}>
+        <div></div>
+        <div></div>
+        <div></div>
+        <div></div>
+      </div>
+    </Fade>
+  );
+};

--- a/src/components/loading-page/loading-page.scss
+++ b/src/components/loading-page/loading-page.scss
@@ -1,0 +1,14 @@
+@import '../../assets/colors';
+@import '../../assets/styles';
+.c-loading-page {
+  margin-top: 150px;
+  width: 100%;
+  flex-direction: column;
+  gap: 40px;
+  @include flex-center;
+
+  .c-loading-page-label {
+    color: $light-blue;
+    font-size: 20px;
+  }
+}

--- a/src/components/loading-page/loading-page.tsx
+++ b/src/components/loading-page/loading-page.tsx
@@ -1,0 +1,39 @@
+import './loading-page.scss';
+import React from 'react';
+import { LoadingIcon } from '../../assets/icons/loading-icon/loading-icon';
+import { motion } from 'framer-motion';
+
+interface LoadingPageProps {
+  className?: string;
+  label?: string;
+  size?: 'small' | 'medium' | 'large';
+  fadeIn?: boolean;
+}
+
+export const LoadingPage = ({ className = '', label = 'loading deck...' }: LoadingPageProps) => {
+  const variants = {
+    invisible: {
+      opacity: 0,
+      y: -50,
+    },
+    visible: {
+      opacity: 1,
+      transition: { delay: 1.5 },
+      y: 0,
+    },
+  };
+
+  return (
+    <div className={`c-loading-page ${className}`}>
+      <LoadingIcon size="large" />
+      <motion.div
+        className="c-loading-page-label"
+        variants={variants}
+        animate={'visible'}
+        initial={'invisible'}
+      >
+        {label}
+      </motion.div>
+    </div>
+  );
+};

--- a/src/components/loading-page/loading-page.tsx
+++ b/src/components/loading-page/loading-page.tsx
@@ -6,11 +6,9 @@ import { motion } from 'framer-motion';
 interface LoadingPageProps {
   className?: string;
   label?: string;
-  size?: 'small' | 'medium' | 'large';
-  fadeIn?: boolean;
 }
 
-export const LoadingPage = ({ className = '', label = 'loading deck...' }: LoadingPageProps) => {
+export const LoadingPage = ({ className = '', label = '' }: LoadingPageProps) => {
   const variants = {
     invisible: {
       opacity: 0,


### PR DESCRIPTION
added `LoadingIcon` and `LoadingPage`
`LoadingIcon` has three sizes: `small`, `medium`, and `large`
`LoadingPage` has a label that slides in on a delay for longer wait times

https://user-images.githubusercontent.com/39753553/163585002-9dd30ace-4809-4823-a63b-a6b169c5db09.mov


https://user-images.githubusercontent.com/39753553/163585043-02fc44f4-92b6-4722-9f5f-16fc5d0e5451.mov


