### PR TITLE
Decks recoil state

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "react-dom": "^17.0.2",
         "react-router-dom": "^6.3.0",
         "react-scripts": "5.0.0",
+        "recoil": "^0.7.2",
         "sass": "^1.49.9",
         "typescript": "^4.5.5",
         "uuid": "^8.3.2",
@@ -9691,6 +9692,11 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/hamt_plus": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/hamt_plus/-/hamt_plus-1.0.2.tgz",
+      "integrity": "sha1-4hwlKWjH4zsg9qGwlM2FeHomVgE="
+    },
     "node_modules/handle-thing": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-2.0.1.tgz",
@@ -15705,6 +15711,25 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/recoil": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/recoil/-/recoil-0.7.2.tgz",
+      "integrity": "sha512-OT4pI7FOUHcIoRtjsL5Lqq+lFFzQfir4MIbUkqyJ3nqv3WfBP1pHepyurqTsK5gw+T+I2R8+uOD28yH+Lg5o4g==",
+      "dependencies": {
+        "hamt_plus": "1.0.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.13.1"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
       }
     },
     "node_modules/recursive-readdir": {
@@ -26247,6 +26272,11 @@
         "duplexer": "^0.1.2"
       }
     },
+    "hamt_plus": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/hamt_plus/-/hamt_plus-1.0.2.tgz",
+      "integrity": "sha1-4hwlKWjH4zsg9qGwlM2FeHomVgE="
+    },
     "handle-thing": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-2.0.1.tgz",
@@ -30498,6 +30528,14 @@
       "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
       "requires": {
         "picomatch": "^2.2.1"
+      }
+    },
+    "recoil": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/recoil/-/recoil-0.7.2.tgz",
+      "integrity": "sha512-OT4pI7FOUHcIoRtjsL5Lqq+lFFzQfir4MIbUkqyJ3nqv3WfBP1pHepyurqTsK5gw+T+I2R8+uOD28yH+Lg5o4g==",
+      "requires": {
+        "hamt_plus": "1.0.2"
       }
     },
     "recursive-readdir": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "react-dom": "^17.0.2",
     "react-router-dom": "^6.3.0",
     "react-scripts": "5.0.0",
+    "recoil": "^0.7.2",
     "sass": "^1.49.9",
     "typescript": "^4.5.5",
     "uuid": "^8.3.2",

--- a/src/app.test.tsx
+++ b/src/app.test.tsx
@@ -2,11 +2,14 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import App from './app';
 import { BrowserRouter } from 'react-router-dom';
+import { RecoilRoot } from 'recoil';
 
 test('renders learn react link', () => {
   render(
     <BrowserRouter>
-      <App />
+      <RecoilRoot>
+        <App />
+      </RecoilRoot>
     </BrowserRouter>
   );
   const linkElement = screen.getByPlaceholderText(/search my decks/i);

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -3,21 +3,16 @@ import './app.scss';
 import { useState } from 'react';
 import { Sidebar } from './components/sidebar/sidebar';
 import { Header } from './components/header/header';
-import {
-  testEnglishDeck,
-  testJapaneseVerbsDeck,
-  testNPTEPartNumberDeck,
-} from './models/mock/deck.mock';
 import { PageRoutes } from './routes';
-
-const testDecks = [testEnglishDeck(0), testJapaneseVerbsDeck(1), testNPTEPartNumberDeck(2, 1)];
+import { userDecksState } from './state/user-decks';
+import { useRecoilValue } from 'recoil';
 
 function App() {
-  const [showDecks, setShowDecks] = useState(true);
+  const userDecks = useRecoilValue(userDecksState);
 
   return (
     <div className="App">
-      <Header decks={testDecks} />
+      <Header decks={userDecks} />
       <Sidebar />
       <div className="page-wrap">
         <div className="content">

--- a/src/helpers/sort.ts
+++ b/src/helpers/sort.ts
@@ -1,0 +1,28 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+/**
+ * Compares the two items and returns:
+ *  -  1 if a > b
+ *  -  0 if a == b
+ *  - -1 if a < b
+ *
+ * Both parameters must be 'comparable' using =, <, >, <=, >=, operators.
+ */
+export function compare(a: any, b: any): number {
+  return Number(a > b) - Number(b > a);
+}
+
+/**
+ * Shuffle the array using Durstenfeld shuffle, an optimized version of Fisher-Yates.
+ * @param arr any array to be shuffled
+ */
+export function shuffle<T>(arr: T[]): T[] {
+  const newArr = [...arr];
+
+  for (let i = newArr.length - 1; i >= 1; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [newArr[i], newArr[j]] = [newArr[j], newArr[i]]; // swap
+  }
+
+  return newArr;
+}

--- a/src/hooks/api/use-decks-client.ts
+++ b/src/hooks/api/use-decks-client.ts
@@ -69,6 +69,10 @@ export function useDecksClient() {
           access: obj['access'],
           frontLang: obj['default_flang'],
           backLang: obj['default_blang'],
+          ownerId: obj['ownerId'],
+          dateCreated: new Date(obj['date_created']),
+          dateUpdated: new Date(obj['date_updated']),
+          dateTouched: new Date(obj['date_touched']),
         },
         cards: obj['cards'],
       };
@@ -91,6 +95,10 @@ export function useDecksClient() {
           access: obj['access'],
           frontLang: obj['default_flang'],
           backLang: obj['default_blang'],
+          ownerId: obj['ownerId'],
+          dateCreated: new Date(obj['date_created']),
+          dateUpdated: new Date(obj['date_updated']),
+          dateTouched: new Date(obj['date_touched']),
         },
         cards: obj['cards'],
       };

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,11 +4,14 @@ import './index.scss';
 import App from './app';
 import reportWebVitals from './reportWebVitals';
 import { BrowserRouter } from 'react-router-dom';
+import { RecoilRoot } from 'recoil';
 
 ReactDOM.render(
   <React.StrictMode>
     <BrowserRouter>
-      <App />
+      <RecoilRoot>
+        <App />
+      </RecoilRoot>
     </BrowserRouter>
   </React.StrictMode>,
   document.getElementById('root')

--- a/src/models/deck.ts
+++ b/src/models/deck.ts
@@ -13,6 +13,10 @@ export interface DeckMetaData {
   access: Access;
   frontLang: Language;
   backLang: Language;
+  ownerId: string;
+  dateCreated: Date;
+  dateUpdated: Date;
+  dateTouched: Date;
 }
 export interface Deck {
   metaData: DeckMetaData;
@@ -27,6 +31,10 @@ export function createNewDeck(): Deck {
     access: 'Private',
     frontLang: 'English',
     backLang: 'English',
+    ownerId: 'unknown-user',
+    dateCreated: new Date(),
+    dateUpdated: new Date(),
+    dateTouched: new Date(),
   };
   return { cards: [], metaData };
 }

--- a/src/models/mock/deck.mock.ts
+++ b/src/models/mock/deck.mock.ts
@@ -1,5 +1,11 @@
 import { Deck, DeckMetaData } from '../deck';
 
+const mockDates = {
+  dateCreated: new Date(),
+  dateUpdated: new Date(),
+  dateTouched: new Date(),
+};
+
 export const testEnglishDeck = (id: number): Deck => {
   const metaData: DeckMetaData = {
     id: id,
@@ -8,6 +14,8 @@ export const testEnglishDeck = (id: number): Deck => {
     access: 'Private',
     frontLang: 'English',
     backLang: 'English',
+    ownerId: 'test-id',
+    ...mockDates,
   };
   return { metaData, cards: [] };
 };
@@ -20,6 +28,8 @@ export const testJapaneseVerbsDeck = (id: number): Deck => {
     access: 'Private',
     frontLang: 'English',
     backLang: 'English',
+    ownerId: 'test-id',
+    ...mockDates,
   };
   return { metaData, cards: [] };
 };
@@ -32,6 +42,8 @@ export const testNPTEPartNumberDeck = (id: number, partNumber: number): Deck => 
     access: 'Private',
     frontLang: 'English',
     backLang: 'English',
+    ownerId: 'test-id',
+    ...mockDates,
   };
   return { metaData, cards: [] };
 };

--- a/src/state/user-decks.ts
+++ b/src/state/user-decks.ts
@@ -9,7 +9,13 @@ export const userDecksState = atom<Deck[]>({
   default: [testEnglishDeck(0)],
 });
 
-export const SortRules = ['sequential', 'last created', 'random'] as const;
+export const SortRules = [
+  'sequential',
+  'last created',
+  'last updated',
+  'last studied',
+  'random',
+] as const;
 export type SortRule = typeof SortRules[number];
 
 // mutatable: sort order
@@ -33,11 +39,17 @@ export const userDecksSortedState = selector<Deck[]>({
       case 'last created':
         return decks.sort((a, b) => compare(b.metaData.dateCreated, a.metaData.dateCreated)); // descending
 
+      case 'last updated':
+        return decks.sort((a, b) => compare(b.metaData.dateUpdated, a.metaData.dateUpdated)); // descending
+
+      case 'last studied':
+        return decks.sort((a, b) => compare(b.metaData.dateTouched, a.metaData.dateTouched)); // descending
+
       case 'random':
         return shuffle(decks);
     }
   },
   cachePolicy_UNSTABLE: {
-    eviction: 'most-recent', // should evict when atoms since 'random' sort isn't determistic
+    eviction: 'most-recent', // should evict when atoms since 'random' sort isn't deterministic
   },
 });

--- a/src/state/user-decks.ts
+++ b/src/state/user-decks.ts
@@ -31,7 +31,7 @@ export const userDecksSortedState = selector<Deck[]>({
         return decks.sort(); // natural ordering
 
       case 'last created':
-        return decks.sort((a, b) => compare(a.metaData.dateCreated, b.metaData.dateCreated));
+        return decks.sort((a, b) => compare(b.metaData.dateCreated, a.metaData.dateCreated)); // descending
 
       case 'random':
         return shuffle(decks);

--- a/src/state/user-decks.ts
+++ b/src/state/user-decks.ts
@@ -1,0 +1,43 @@
+import { atom, selector } from 'recoil';
+import { compare, shuffle } from '../helpers/sort';
+import { Deck } from '../models/deck';
+import { testEnglishDeck } from '../models/mock/deck.mock';
+
+// mutatable: raw user decks
+export const userDecksState = atom<Deck[]>({
+  key: 'userDecksState',
+  default: [testEnglishDeck(0)],
+});
+
+export const SortRules = ['sequential', 'last created', 'random'] as const;
+export type SortRule = typeof SortRules[number];
+
+// mutatable: sort order
+export const userDecksSortRuleState = atom<SortRule>({
+  key: 'userDecksSortRuleState',
+  default: 'last created',
+});
+
+// viewonly: user decks sorted by sort order (via `userDecksSortRule`)
+export const userDecksSortedState = selector<Deck[]>({
+  key: 'userDecksSortedState',
+  get: ({ get }) => {
+    const sortRule = get(userDecksSortRuleState); // readonly
+    const getDecks = get(userDecksState); // readonly
+    const decks = [...getDecks];
+
+    switch (sortRule) {
+      case 'sequential':
+        return decks.sort(); // natural ordering
+
+      case 'last created':
+        return decks.sort((a, b) => compare(a.metaData.dateCreated, b.metaData.dateCreated));
+
+      case 'random':
+        return shuffle(decks);
+    }
+  },
+  cachePolicy_UNSTABLE: {
+    eviction: 'most-recent', // should evict when atoms since 'random' sort isn't determistic
+  },
+});


### PR DESCRIPTION
started the basis of using `Recoil` with this PR

**summary of Recoil and how it's used here:**
- `atoms` are the simplest form of state (key, value) pair
   - access using `useRecoilState` or if you only need the setter/getter `useSetRecoilState`/`useRecoilValue` respectively
- `selectors` are derived states, they update when atoms they depend on change
   - for example, sorted decks should update when the user deck **_or_** sort option selected changes
   - (i.e.) in this PR,  `userDecksSortedState` depends on the atoms: `userDecksState` and `userDecksSortedState`
- just like React's `useState`, whenever one of the recoil state changes, the component that consumes it is rerendered

**summary of changes:**
- add extra properties to `DeckMetadata`, we need this to sort by last created, say... maybe we want a _last updated_ option too?
- user decks are a recoil state, so is the selected sorting option; however, to view the sorted decks, we should subscribe to the sorted user decks and NOT user decks
  - this is extremely useful if we want to persist the sorting state in a future component aka the search page
- search bar data consumes the user decks recoil state, so the dropdown should update accordingly

https://user-images.githubusercontent.com/29434693/163634296-d506bc62-eb26-4e9c-963c-f1d020cd3d3c.mp4


