### PR TITLE
Add way too many tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "start": "craco start",
     "build": "craco build",
     "test": "craco test",
+    "coverage": "npm run test -- --coverage .",
     "lint": "npx eslint src test",
     "lint:fix": "npm run lint -- --fix",
     "prettier": "npx prettier src test --check",

--- a/src/app.test.tsx
+++ b/src/app.test.tsx
@@ -1,16 +1,25 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import App from './app';
-import { BrowserRouter } from 'react-router-dom';
+import { unstable_HistoryRouter as HistoryRouter } from 'react-router-dom';
 import { RecoilRoot } from 'recoil';
+import { createMemoryHistory } from 'history';
+
+export function renderWithHistoryRouter(
+  jsxElement: JSX.Element,
+  { route = '/', history = createMemoryHistory({ initialEntries: [route] }) } = {}
+) {
+  return {
+    history,
+    ...render(<HistoryRouter history={history}>{jsxElement}</HistoryRouter>),
+  };
+}
 
 test('renders learn react link', () => {
-  render(
-    <BrowserRouter>
-      <RecoilRoot>
-        <App />
-      </RecoilRoot>
-    </BrowserRouter>
+  renderWithHistoryRouter(
+    <RecoilRoot>
+      <App />
+    </RecoilRoot>
   );
   const linkElement = screen.getByPlaceholderText(/search my decks/i);
   expect(linkElement).toBeInTheDocument();

--- a/src/components/button/button.test.tsx
+++ b/src/components/button/button.test.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { Button } from './button';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { noop } from '../../helpers/func';
+
+const TEST_CHILDREN = 'TEST_CHILDREN';
+
+describe('Button', () => {
+  it('should render correctly with default props', () => {
+    render(<Button onClick={noop}>{TEST_CHILDREN}</Button>);
+    expect(screen.queryByText(TEST_CHILDREN)).toBeInTheDocument();
+  });
+
+  it('should fire onClick when pressed', () => {
+    const mockOnClick = jest.fn();
+    render(<Button onClick={mockOnClick}>{TEST_CHILDREN}</Button>);
+
+    userEvent.click(screen.getByText(TEST_CHILDREN));
+    expect(mockOnClick).toBeCalled();
+  });
+
+  it('should not propagate when `bubbleOnClickEvent` is false', () => {
+    const mockOnClickOuter = jest.fn();
+    const mockOnClickInner = jest.fn();
+    render(
+      <div onClick={mockOnClickOuter}>
+        <Button onClick={mockOnClickInner} bubbleOnClickEvent={false}>
+          {TEST_CHILDREN}
+        </Button>
+      </div>
+    );
+
+    userEvent.click(screen.getByText(TEST_CHILDREN));
+    expect(mockOnClickOuter).not.toBeCalled();
+    expect(mockOnClickInner).toBeCalled();
+  });
+});

--- a/src/components/deck-cover/deck-cover.test.tsx
+++ b/src/components/deck-cover/deck-cover.test.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { DeckCover } from './deck-cover';
+import { noop } from '../../helpers/func';
+import { testEnglishDeck } from '../../models/mock/deck.mock';
+import userEvent from '@testing-library/user-event';
+
+const TEST_DECK = testEnglishDeck(0);
+
+describe('DeckCover', () => {
+  it('should render correctly with default props', () => {
+    render(<DeckCover deck={TEST_DECK} onStudyClick={noop} onViewClick={noop} />);
+    expect(screen.queryAllByText(TEST_DECK.metaData.title)[0]).toBeVisible();
+  });
+
+  it('should not fire `onClick` if set to not flippable', () => {
+    const mockOnClick = jest.fn();
+    render(
+      <DeckCover
+        deck={TEST_DECK}
+        onClick={mockOnClick}
+        flippable={false}
+        onStudyClick={noop}
+        onViewClick={noop}
+      />
+    );
+
+    userEvent.click(screen.queryAllByText(TEST_DECK.metaData.title)[0]);
+    expect(mockOnClick).toBeCalled();
+  });
+
+  it('should fire all click listeners', () => {
+    const mockAllOnClick = jest.fn();
+    render(
+      <DeckCover
+        deck={TEST_DECK}
+        onClick={mockAllOnClick}
+        onStudyClick={mockAllOnClick}
+        onViewClick={mockAllOnClick}
+      />
+    );
+
+    userEvent.click(screen.queryAllByText(TEST_DECK.metaData.title)[0]);
+    userEvent.click(screen.getByText('view'));
+    userEvent.click(screen.getByText('study'));
+    expect(mockAllOnClick).toBeCalledTimes(3);
+  });
+});

--- a/src/components/drop-down-options/drop-down-options.test.tsx
+++ b/src/components/drop-down-options/drop-down-options.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { DropDownOption, DropDownOptions } from './drop-down-options';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitForElementToBeRemoved } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { noop } from '../../helpers/func';
 import {
@@ -16,15 +16,16 @@ describe('Button', () => {
     expect(screen.queryByText(TEST_OPTIONS_SINGLE_VALUES[0])).toBeVisible();
   });
 
-  it('should hide when component rerenders with show as false', () => {
-    const { rerender, unmount } = render(
+  it('should hide when component rerenders with show as false', async () => {
+    const { rerender } = render(
       <DropDownOptions show={true} options={TEST_OPTIONS_SINGLE} onOptionSelect={noop} />
     );
     expect(screen.queryByText(TEST_OPTIONS_SINGLE_VALUES[0])).toBeVisible();
 
-    unmount(); // i think this is needed since AnimatePresence keeps old component alive despite wait(...)
     rerender(<DropDownOptions show={false} options={TEST_OPTIONS_SINGLE} onOptionSelect={noop} />);
-    expect(screen.queryByText(TEST_OPTIONS_SINGLE_VALUES[0])).toBeNull();
+    await waitForElementToBeRemoved(() => screen.queryByText(TEST_OPTIONS_SINGLE_VALUES[0]), {
+      timeout: 500, // wrt `Fade` having transition duration of 0.2 (200ms)
+    });
   });
 
   it('should click the right dropdown option', () => {

--- a/src/components/drop-down-options/drop-down-options.test.tsx
+++ b/src/components/drop-down-options/drop-down-options.test.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { DropDownOption, DropDownOptions } from './drop-down-options';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { noop } from '../../helpers/func';
+import {
+  TEST_OPTIONS_SINGLE,
+  TEST_OPTIONS_SINGLE_VALUES,
+  TEST_OPTIONS_SMALL,
+  TEST_OPTIONS_SMALL_VALUES,
+} from './options.mock';
+
+describe('Button', () => {
+  it('should render correctly with default props', () => {
+    render(<DropDownOptions show={true} options={TEST_OPTIONS_SINGLE} onOptionSelect={noop} />);
+    expect(screen.queryByText(TEST_OPTIONS_SINGLE_VALUES[0])).toBeVisible();
+  });
+
+  it('should hide when component rerenders with show as false', () => {
+    const { rerender, unmount } = render(
+      <DropDownOptions show={true} options={TEST_OPTIONS_SINGLE} onOptionSelect={noop} />
+    );
+    expect(screen.queryByText(TEST_OPTIONS_SINGLE_VALUES[0])).toBeVisible();
+
+    unmount(); // i think this is needed since AnimatePresence keeps old component alive despite wait(...)
+    rerender(<DropDownOptions show={false} options={TEST_OPTIONS_SINGLE} onOptionSelect={noop} />);
+    expect(screen.queryByText(TEST_OPTIONS_SINGLE_VALUES[0])).toBeNull();
+  });
+
+  it('should click the right dropdown option', () => {
+    const mockOnOptionSelect = jest.fn();
+    render(
+      <DropDownOptions
+        show={true}
+        options={TEST_OPTIONS_SMALL}
+        onOptionSelect={(option: DropDownOption) => mockOnOptionSelect(option.value)}
+      />
+    );
+
+    // target element at index 1 (so, 2nd element)
+    const secondOptionText = TEST_OPTIONS_SMALL_VALUES[1];
+    userEvent.click(screen.getByText(secondOptionText));
+    expect(mockOnOptionSelect).toBeCalledWith(secondOptionText);
+  });
+});

--- a/src/components/drop-down-options/options.mock.ts
+++ b/src/components/drop-down-options/options.mock.ts
@@ -9,18 +9,17 @@ export const createTestOptions = (size: number): DropDownOption[] =>
   }));
 
 export const TEST_OPTIONS_SINGLE: DropDownOption[] = createTestOptions(1);
-export const TEST_OPTIONS_SINGLE_VALUES: string[] = TEST_OPTIONS_SINGLE.map(getValueAsString)
+export const TEST_OPTIONS_SINGLE_VALUES: string[] = TEST_OPTIONS_SINGLE.map(getValueAsString);
 
 export const TEST_OPTIONS_SMALL: DropDownOption[] = createTestOptions(10);
-export const TEST_OPTIONS_SMALL_VALUES: string[] = TEST_OPTIONS_SMALL.map(getValueAsString)
+export const TEST_OPTIONS_SMALL_VALUES: string[] = TEST_OPTIONS_SMALL.map(getValueAsString);
 
 export const TEST_OPTIONS_MEDIUM: DropDownOption[] = createTestOptions(100);
-export const TEST_OPTIONS_MEDIUM_VALUES: string[] = TEST_OPTIONS_MEDIUM.map(getValueAsString)
+export const TEST_OPTIONS_MEDIUM_VALUES: string[] = TEST_OPTIONS_MEDIUM.map(getValueAsString);
 
 export const TEST_OPTIONS_LARGE: DropDownOption[] = createTestOptions(1000);
-export const TEST_OPTIONS_LARGE_VALUES: string[] = TEST_OPTIONS_LARGE.map(getValueAsString)
+export const TEST_OPTIONS_LARGE_VALUES: string[] = TEST_OPTIONS_LARGE.map(getValueAsString);
 
-
-function getValueAsString(option: DropDownOption){
+function getValueAsString(option: DropDownOption) {
   return option.value as string;
 }

--- a/src/components/drop-down/drop-down.test.tsx
+++ b/src/components/drop-down/drop-down.test.tsx
@@ -77,6 +77,6 @@ describe('DropDown', () => {
     userEvent.click(screen.getByText(TEST_BUTTON_LABEL));
     userEvent.click(screen.getByText(TEST_OPTIONS_SMALL_VALUES[0]));
 
-    expect(mockOnOptionSelect).toHaveBeenCalledWith(TEST_OPTIONS_SMALL[0]);
+    expect(mockOnOptionSelect).toBeCalledWith(TEST_OPTIONS_SMALL[0]);
   });
 });

--- a/src/components/flashcard-set/flashcard-set.test.tsx
+++ b/src/components/flashcard-set/flashcard-set.test.tsx
@@ -1,0 +1,112 @@
+import React from 'react';
+import { FlashcardSet } from './flashcard-set';
+import { render, screen } from '@testing-library/react';
+import { getTestFoxCard, getTestMonkeyCard, getTestMouseCard } from '../../models/mock/card.mock';
+import userEvent from '@testing-library/user-event';
+import { Card } from '../../models/card';
+import { scryRenderedComponentsWithType } from 'react-dom/test-utils';
+
+// warning: don't mutate these!!!
+const TEST_FOX_CARD = getTestFoxCard();
+const TEST_MONKEY_CARD = getTestMonkeyCard();
+const TEST_MOUSE_CARD = getTestMouseCard();
+const FOX_MONKEY_MOUSE = [TEST_FOX_CARD, TEST_MONKEY_CARD, TEST_MOUSE_CARD];
+
+describe('FlashcardSet', () => {
+  it('should render correctly with default props', () => {
+    render(<FlashcardSet cards={[TEST_FOX_CARD]} />);
+    expect(screen.queryByDisplayValue(TEST_FOX_CARD.front.text)).toBeInTheDocument();
+    expect(screen.queryByDisplayValue(TEST_FOX_CARD.back.text)).toBeInTheDocument();
+  });
+
+  it('should render correctly with multiple cards', () => {
+    render(<FlashcardSet cards={FOX_MONKEY_MOUSE} />);
+    expect(screen.queryAllByDisplayValue(TEST_MONKEY_CARD.front.text).length).toBe(1);
+    expect(screen.queryAllByDisplayValue(TEST_MONKEY_CARD.front.text).length).toBe(1);
+    expect(screen.queryAllByDisplayValue(TEST_MOUSE_CARD.front.text).length).toBe(1);
+  });
+
+  it('should call `onDeleteCardClick` when trash icon is clicked', () => {
+    const mockOnDeleteCard = jest.fn();
+    render(
+      <FlashcardSet
+        variant="editable"
+        cards={FOX_MONKEY_MOUSE}
+        onDeleteCardClick={mockOnDeleteCard}
+      />
+    );
+
+    // click the trash icon on the first card
+    const firstTrashIcon = screen.queryAllByRole('button', { name: 'trash' })[0];
+    userEvent.click(firstTrashIcon);
+    expect(mockOnDeleteCard).toBeCalledWith(FOX_MONKEY_MOUSE[0]);
+  });
+
+  it('should move card up and wrap around when up-arrow clicked', () => {
+    const mockOnCardReorder = jest.fn();
+    render(
+      <FlashcardSet
+        variant="editable"
+        cards={FOX_MONKEY_MOUSE}
+        onCardReorder={(cards: Card[]) => mockOnCardReorder(cards.map((card) => card.front.text))}
+      />
+    );
+
+    // up on MONKEY: FOX_MONKEY_MOUSE --> MONKEY_FOX_MOUSE
+    userEvent.click(getUpArrowByIndex(1));
+    expect(mockOnCardReorder).toBeCalledWith(['monkey', 'fox', 'mouse']);
+  });
+
+  it('should wrap around if up-arrow clicked on topmost card', () => {
+    const mockOnCardReorder = jest.fn();
+    render(
+      <FlashcardSet
+        variant="editable"
+        cards={FOX_MONKEY_MOUSE}
+        onCardReorder={(cards: Card[]) => mockOnCardReorder(cards.map((card) => card.front.text))}
+      />
+    );
+
+    // up on FOX: FOX_MONKEY_MOUSE --> MONKEY_MOUSE_FOX
+    userEvent.click(getUpArrowByIndex(0));
+    expect(mockOnCardReorder).toBeCalledWith(['monkey', 'mouse', 'fox']);
+  });
+
+  it('should move card down when down-arrow clicked', () => {
+    const mockOnCardReorder = jest.fn();
+    render(
+      <FlashcardSet
+        variant="editable"
+        cards={FOX_MONKEY_MOUSE}
+        onCardReorder={(cards: Card[]) => mockOnCardReorder(cards.map((card) => card.front.text))}
+      />
+    );
+
+    // down on MONKEY: FOX_MONKEY_MOUSE --> FOX_MOUSE_MONKEY
+    userEvent.click(getDownArrowByIndex(1));
+    expect(mockOnCardReorder).toBeCalledWith(['fox', 'mouse', 'monkey']);
+  });
+
+  it('should wrap around if down-arrow clicked on bottommost card', () => {
+    const mockOnCardReorder = jest.fn();
+    render(
+      <FlashcardSet
+        variant="editable"
+        cards={FOX_MONKEY_MOUSE}
+        onCardReorder={(cards: Card[]) => mockOnCardReorder(cards.map((card) => card.front.text))}
+      />
+    );
+
+    // down on MOUSE: FOX_MONKEY_MOUSE --> MOUSE_FOX_MONKEY
+    userEvent.click(getDownArrowByIndex(2));
+    expect(mockOnCardReorder).toBeCalledWith(['mouse', 'fox', 'monkey']);
+  });
+
+  function getUpArrowByIndex(index: number): HTMLElement {
+    return screen.queryAllByRole('button', { name: 'up-arrow' })[index];
+  }
+
+  function getDownArrowByIndex(index: number): HTMLElement {
+    return screen.queryAllByRole('button', { name: 'down-arrow' })[index];
+  }
+});

--- a/src/components/flashcard-set/flashcard-set.tsx
+++ b/src/components/flashcard-set/flashcard-set.tsx
@@ -66,8 +66,13 @@ export const FlashcardSet = ({
 
   function handleUpClick(index: number) {
     const newCards = [...cards];
-    newCards[index] = newCards.splice(index - 1, 1, cards[index])[0];
-    handleCardReorder(newCards);
+    if (index === 0) {
+      const [firstCard] = newCards.splice(index, 1);
+      handleCardReorder([...newCards, firstCard]);
+    } else {
+      newCards[index] = newCards.splice(index - 1, 1, cards[index])[0];
+      handleCardReorder(newCards);
+    }
   }
 
   function handleDownClick(index: number) {

--- a/src/components/flashcard/card-face/card-face.test.tsx
+++ b/src/components/flashcard/card-face/card-face.test.tsx
@@ -48,7 +48,7 @@ describe('CardFace', () => {
       />
     );
     userEvent.click(screen.getByRole('button', { name: 'speaker' }));
-    expect(mockOnSpeakerClick).toHaveBeenCalled();
+    expect(mockOnSpeakerClick).toBeCalled();
   });
 
   it('should call onFocus on focus', () => {
@@ -63,7 +63,7 @@ describe('CardFace', () => {
       />
     );
     userEvent.click(screen.getByPlaceholderText(TEST_PLACEHOLDER));
-    expect(mockOnFocus).toHaveBeenCalled();
+    expect(mockOnFocus).toBeCalled();
   });
 
   it('should call onChange on text change', () => {
@@ -78,6 +78,6 @@ describe('CardFace', () => {
       />
     );
     userEvent.type(screen.getByPlaceholderText(TEST_PLACEHOLDER), 't');
-    expect(mockOnChange).toHaveBeenCalledWith({ ...createNewCardContent(), text: 't' });
+    expect(mockOnChange).toBeCalledWith({ ...createNewCardContent(), text: 't' });
   });
 });

--- a/src/components/flashcard/flashcard.test.tsx
+++ b/src/components/flashcard/flashcard.test.tsx
@@ -17,7 +17,7 @@ describe('Flashcard', () => {
     expect(screen.queryByRole('button', { name: 'trash' })).not.toBeInTheDocument();
   });
 
-  it('should show arrows and trash when not readonly', () => {
+  it('should show arrows and trash when not readonly (editable)', () => {
     const testCard = getTestFoxCard();
     render(<Flashcard variant="active" card={testCard} />);
     expect(screen.queryByRole('button', { name: 'up-arrow' })).toBeInTheDocument();

--- a/src/components/flip-tile/flip-tile.scss
+++ b/src/components/flip-tile/flip-tile.scss
@@ -1,4 +1,4 @@
-.flip-tile {
+.c-flip-tile {
   -webkit-perspective: 800px;
   -ms-perspective: 800px;
   perspective: 800px;
@@ -7,7 +7,7 @@
   min-width: 100px;
   min-height: 100px;
 
-  .card {
+  .c-card {
     cursor: pointer;
     width: 100%;
     height: 100%;
@@ -20,8 +20,8 @@
       -webkit-transform 0.8s cubic-bezier(0.175, 0.885, 0.32, 1.275);
   }
 
-  .front,
-  .back {
+  .c-front,
+  .c-back {
     position: absolute;
     width: 100%;
     height: 100%;
@@ -29,11 +29,11 @@
     backface-visibility: hidden;
   }
 
-  .back {
+  .c-back {
     -webkit-transform: rotateY(180deg);
     transform: rotateY(180deg);
   }
-  .card.is-flipped {
+  .c-card.is-flipped {
     -webkit-transform: rotateY(180deg);
     transform: rotateY(180deg);
   }

--- a/src/components/flip-tile/flip-tile.test.tsx
+++ b/src/components/flip-tile/flip-tile.test.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { FlipTile } from './flip-tile';
+import userEvent from '@testing-library/user-event';
+import { noop } from '../../helpers/func';
+
+const TEST_FRONT = 'TEST_FRONT';
+const TEST_BACK = 'TEST_BACK';
+const P_TEST_FRONT = <p>{TEST_FRONT}</p>;
+const P_TEST_BACK = <p>{TEST_BACK}</p>;
+
+describe('FlipTile', () => {
+  it('should render correctly with default props', () => {
+    render(<FlipTile isFlipped={false} front={P_TEST_FRONT} back={P_TEST_BACK} onClick={noop} />);
+    expect(screen.queryByText(TEST_FRONT)).toBeInTheDocument();
+    expect(screen.queryByText(TEST_BACK)).toBeInTheDocument();
+  });
+
+  it('should fire `onClick` when pressed', () => {
+    const mockOnClick = jest.fn();
+    render(
+      <FlipTile isFlipped={false} front={P_TEST_FRONT} back={P_TEST_BACK} onClick={mockOnClick} />
+    );
+    userEvent.click(screen.getByText(TEST_FRONT));
+    expect(mockOnClick).toBeCalled();
+  });
+
+  it('should have `is-flipped` class when `isFlipped` is true', () => {
+    const { container } = render(
+      <FlipTile isFlipped={true} front={P_TEST_FRONT} back={P_TEST_BACK} onClick={noop} />
+    );
+    expect(container.getElementsByClassName('c-card')[0]).toHaveClass('is-flipped');
+  });
+});

--- a/src/components/flip-tile/flip-tile.tsx
+++ b/src/components/flip-tile/flip-tile.tsx
@@ -11,10 +11,10 @@ interface FlipTileProps {
 
 export const FlipTile = ({ isFlipped, front, back, className, onClick }: FlipTileProps) => {
   return (
-    <div className={`flip-tile ${className || ''}`} onClick={onClick}>
-      <div className={`card ${isFlipped ? 'is-flipped' : ''}`}>
-        <div className="front">{front}</div>
-        <div className="back">{back}</div>
+    <div className={`c-flip-tile ${className || ''}`} onClick={onClick}>
+      <div className={`c-card ${isFlipped ? 'is-flipped' : ''}`}>
+        <div className="c-front">{front}</div>
+        <div className="c-back">{back}</div>
       </div>
     </div>
   );

--- a/src/components/header/header.test.tsx
+++ b/src/components/header/header.test.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { Header } from './header';
+import { render, screen } from '@testing-library/react';
+
+describe('Header', () => {
+  it('should render correctly with default props', () => {
+    render(<Header decks={[]} />);
+    expect(screen.queryByText('sign up')).toBeInTheDocument();
+    expect(screen.queryByText('sign in')).toBeInTheDocument();
+  });
+
+  // todo: test sign up, sign in button functionality when hooked up
+});

--- a/src/components/loading-page/loading-page.test.tsx
+++ b/src/components/loading-page/loading-page.test.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { LoadingPage } from './loading-page';
+import { render, screen, waitFor } from '@testing-library/react';
+
+const TEST_LABEL = 'TEST_LABEL';
+
+describe('LoadingPage', () => {
+  it('should render correctly with default props', () => {
+    render(<LoadingPage />);
+    expect(document.querySelector('.c-loading-icon')).toBeTruthy();
+  });
+
+  it('should show label after delay', async () => {
+    render(<LoadingPage label={TEST_LABEL} delay={0.05} />); // 50 ms
+    expect(screen.queryByText(TEST_LABEL)).not.toBeVisible();
+
+    await waitFor(() => expect(screen.queryByText(TEST_LABEL)).toBeVisible(), { timeout: 500 });
+  });
+});

--- a/src/components/loading-page/loading-page.test.tsx
+++ b/src/components/loading-page/loading-page.test.tsx
@@ -11,7 +11,7 @@ describe('LoadingPage', () => {
   });
 
   it('should show label after delay', async () => {
-    render(<LoadingPage label={TEST_LABEL} delay={0.05} />); // 50 ms
+    render(<LoadingPage label={TEST_LABEL} labelDelay={0.05} />); // 50 ms
     expect(screen.queryByText(TEST_LABEL)).not.toBeVisible();
 
     await waitFor(() => expect(screen.queryByText(TEST_LABEL)).toBeVisible(), { timeout: 500 });

--- a/src/components/loading-page/loading-page.tsx
+++ b/src/components/loading-page/loading-page.tsx
@@ -6,9 +6,10 @@ import { motion } from 'framer-motion';
 interface LoadingPageProps {
   className?: string;
   label?: string;
+  delay?: number; // in seconds
 }
 
-export const LoadingPage = ({ className = '', label = '' }: LoadingPageProps) => {
+export const LoadingPage = ({ className = '', label = '', delay = 1.5 }: LoadingPageProps) => {
   const variants = {
     invisible: {
       opacity: 0,
@@ -16,7 +17,7 @@ export const LoadingPage = ({ className = '', label = '' }: LoadingPageProps) =>
     },
     visible: {
       opacity: 1,
-      transition: { delay: 1.5 },
+      transition: { delay: delay },
       y: 0,
     },
   };

--- a/src/components/loading-page/loading-page.tsx
+++ b/src/components/loading-page/loading-page.tsx
@@ -6,10 +6,10 @@ import { motion } from 'framer-motion';
 interface LoadingPageProps {
   className?: string;
   label?: string;
-  delay?: number; // in seconds
+  labelDelay?: number; // in seconds
 }
 
-export const LoadingPage = ({ className = '', label = '', delay = 1.5 }: LoadingPageProps) => {
+export const LoadingPage = ({ className = '', label = '', labelDelay = 1.5 }: LoadingPageProps) => {
   const variants = {
     invisible: {
       opacity: 0,
@@ -17,7 +17,7 @@ export const LoadingPage = ({ className = '', label = '', delay = 1.5 }: Loading
     },
     visible: {
       opacity: 1,
-      transition: { delay: delay },
+      transition: { delay: labelDelay },
       y: 0,
     },
   };

--- a/src/components/page-header/page-header.scss
+++ b/src/components/page-header/page-header.scss
@@ -1,6 +1,6 @@
 @import '../../assets/styles';
 
-.page-header {
+.c-page-header {
   display: flex;
   flex-direction: column;
   gap: 8px;

--- a/src/components/page-header/page-header.test.tsx
+++ b/src/components/page-header/page-header.test.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { PageHeader } from './page-header';
+import { render, screen } from '@testing-library/react';
+import { noop } from '../../helpers/func';
+import userEvent from '@testing-library/user-event';
+
+const TEST_LABEL = 'TEST_LABEL';
+
+describe('PageHeader', () => {
+  it('should render correctly with default props', () => {
+    render(<PageHeader label={TEST_LABEL} onGoBackClick={noop} />);
+    expect(screen.queryByText(TEST_LABEL)).toBeInTheDocument();
+  });
+
+  it('should trigger `onGoBackClick` when button pressed', () => {
+    const mockOnGoBackClick = jest.fn();
+    render(<PageHeader label={TEST_LABEL} onGoBackClick={mockOnGoBackClick} />);
+
+    userEvent.click(screen.getByText('back to decks'));
+    expect(mockOnGoBackClick).toBeCalled();
+  });
+});

--- a/src/components/page-header/page-header.tsx
+++ b/src/components/page-header/page-header.tsx
@@ -10,7 +10,7 @@ interface PageHeaderProps {
 
 export const PageHeader = ({ label, onGoBackClick }: PageHeaderProps) => {
   return (
-    <div className="page-header">
+    <div className="c-page-header">
       <Button variant="invisible" onClick={onGoBackClick} className="go-back-button">
         <BackArrowIcon /> back to decks
       </Button>

--- a/src/components/progress-bar/progress-bar.scss
+++ b/src/components/progress-bar/progress-bar.scss
@@ -2,23 +2,23 @@
 
 $height: 10px;
 
-.progress-bar {
+.c-progress-bar {
   display: flex;
   flex-direction: column;
 
-  label.bar-label {
+  label.c-bar-label {
     font-size: 10px;
     white-space: nowrap;
   }
 
-  .outer-bar {
+  .c-outer-bar {
     background-color: $white;
     border: 1px solid $blue;
     border-radius: $height;
     height: $height;
     width: 100%;
 
-    .inner-bar {
+    .c-inner-bar {
       border: inherit;
       border-radius: inherit;
       height: $height;
@@ -31,7 +31,7 @@ $height: 10px;
   &.label-on-right {
     flex-direction: row-reverse;
 
-    label.bar-label {
+    label.c-bar-label {
       margin-left: 5px;
     }
   }

--- a/src/components/progress-bar/progress-bar.test.tsx
+++ b/src/components/progress-bar/progress-bar.test.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { ProgressBar } from './progress-bar';
+import { render, screen } from '@testing-library/react';
+
+const TEST_LABEL = 'TEST_LABEL';
+
+describe('ProgressBar', () => {
+  it('should render correctly with default props', () => {
+    render(<ProgressBar percent={50} label={TEST_LABEL} />);
+    expect(screen.queryByText(TEST_LABEL)).toBeInTheDocument();
+  });
+
+  it('should not render percentage bar if 0%', () => {
+    const { container } = render(<ProgressBar percent={0} label={TEST_LABEL} />);
+    expect(container.getElementsByClassName('c-inner-bar').length).toBe(0);
+  });
+
+  it('should be filled in half-way when set to 50%', () => {
+    const { container } = render(<ProgressBar percent={50} label={TEST_LABEL} />);
+    expect(container.getElementsByClassName('c-inner-bar').length).toBe(1);
+    expect(container.getElementsByClassName('c-inner-bar')[0]).toHaveStyle({ width: '50%' });
+  });
+});

--- a/src/components/progress-bar/progress-bar.tsx
+++ b/src/components/progress-bar/progress-bar.tsx
@@ -9,10 +9,10 @@ interface ProgressBarProps {
 
 export const ProgressBar = ({ percent, label, variant = 'label-on-top' }: ProgressBarProps) => {
   return (
-    <div className={`progress-bar ${variant}`}>
-      <label className="bar-label">{label}</label>
-      <div className="outer-bar">
-        {percent > 0 && <div className="inner-bar" style={{ width: `${percent}%` }}></div>}
+    <div className={`c-progress-bar ${variant}`}>
+      <label className="c-bar-label">{label}</label>
+      <div className="c-outer-bar">
+        {percent > 0 && <div className="c-inner-bar" style={{ width: `${percent}%` }}></div>}
       </div>
     </div>
   );

--- a/src/components/sidebar/sidebar.test.tsx
+++ b/src/components/sidebar/sidebar.test.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { Sidebar } from './sidebar';
+import { screen } from '@testing-library/react';
+import { SIDEBAR_ROUTE_ITEMS } from './sidebar-routes';
+import { renderWithHistoryRouter } from '../../app.test';
+import userEvent from '@testing-library/user-event';
+
+const FIRST_SIDEBAR_ITEM_NAME = SIDEBAR_ROUTE_ITEMS[0].name;
+const FIRST_SIDEBAR_ITEM_ROUTE = SIDEBAR_ROUTE_ITEMS[0].route;
+
+describe('SideBar', () => {
+  it('should render correctly with default props', () => {
+    renderWithHistoryRouter(<Sidebar />);
+    expect(screen.getByText(FIRST_SIDEBAR_ITEM_NAME)).toBeInTheDocument();
+  });
+
+  it('should change url when clicking link item', () => {
+    const { history } = renderWithHistoryRouter(<Sidebar />);
+    expect(history.location.pathname).toBe('/');
+
+    userEvent.click(screen.getByText(FIRST_SIDEBAR_ITEM_NAME));
+    expect(history.location.pathname).toBe(FIRST_SIDEBAR_ITEM_ROUTE);
+  });
+});

--- a/src/pages/edit-deck-page/deck-editor/deck-editor.test.tsx
+++ b/src/pages/edit-deck-page/deck-editor/deck-editor.test.tsx
@@ -119,7 +119,7 @@ describe('DeckEditor', () => {
     userEvent.click(screen.getByText('advanced settings'));
     userEvent.click(screen.getByText('delete deck'));
 
-    expect(mockOnDeleteDeckClick).toHaveBeenCalled();
+    expect(mockOnDeleteDeckClick).toBeCalled();
   });
 
   it('should call onGoBackClick when go back is clicked', () => {
@@ -135,7 +135,7 @@ describe('DeckEditor', () => {
     );
     userEvent.click(screen.getByText('back to decks'));
 
-    expect(mockOnGoBackClick).toHaveBeenCalled();
+    expect(mockOnGoBackClick).toBeCalled();
   });
 
   it('should call onCreateDeckClick when create is clicked', () => {
@@ -151,7 +151,7 @@ describe('DeckEditor', () => {
     );
     userEvent.click(screen.getByText('create'));
 
-    expect(mockOnCreateDeckClick).toHaveBeenCalled();
+    expect(mockOnCreateDeckClick).toBeCalled();
   });
 
   it('should be reset when initialDeck is changed', () => {

--- a/src/pages/edit-deck-page/deck-editor/meta-data-editor/meta-data-editor.test.tsx
+++ b/src/pages/edit-deck-page/deck-editor/meta-data-editor/meta-data-editor.test.tsx
@@ -49,7 +49,7 @@ describe('MetaDataEditor', () => {
       />
     );
     userEvent.type(screen.getByDisplayValue(metaData.title), 't');
-    expect(mockOnDeckChange).toHaveBeenCalled();
+    expect(mockOnDeckChange).toBeCalled();
   });
 
   it('should call onDeckChange when meta data is changed', () => {
@@ -65,6 +65,6 @@ describe('MetaDataEditor', () => {
     userEvent.click(screen.getByText('advanced settings'));
     userEvent.click(screen.getByText('delete deck'));
 
-    expect(mockOnDeleteClick).toHaveBeenCalled();
+    expect(mockOnDeleteClick).toBeCalled();
   });
 });


### PR DESCRIPTION
add tests for every component, a couple components aren't finished... (i.e. header) 
but we should test that it displays properly at the minimum

---

* notable changes aside from tests
  - improve class names for `FlipTile`, `PageHeader`, `ProgressBar`
  - add `labelDelay` as a prop for `LoadingPage`
  - add `renderWithHistoryRouter` to easily test components that can change the URL 
    - as an example, see: `sidebar.test.tsx`
  - `handleUpClick` for `FlashcardSet` now wraps around properly when clicking on the first card (it use to just swap with last)
  
---

* also added `npm run coverage` to get a feeling of how well-tested we are
  - this may be misleading since this coverage includes _helpers_, _hooks_, and _models_

before:
![test-coverage-before](https://user-images.githubusercontent.com/29434693/163731596-605bd6dc-a5a9-40b7-a8e3-4e51a3f4bdd9.png)

after:
![test-coverage-after](https://user-images.githubusercontent.com/29434693/163731599-b980b4ac-9797-4250-92b9-90173556e6d7.png)

