### PR TITLE
added deck cover transition

### DIFF
--- a/src/components/deck-cover/deck-cover.tsx
+++ b/src/components/deck-cover/deck-cover.tsx
@@ -4,6 +4,7 @@ import { FlipTile } from '../flip-tile/flip-tile';
 import { ProgressBar } from '../progress-bar/progress-bar';
 import { Button } from '../button/button';
 import { Deck } from '../../models/deck';
+import { motion } from 'framer-motion';
 
 interface DeckCoverProps {
   flippable?: boolean;
@@ -23,14 +24,21 @@ export const DeckCover = ({
   // false => show front; true => show back
   const [flipped, setFlipped] = useState(false);
 
+  const springTransition = {
+    type: 'spring',
+    damping: 25,
+    stiffness: 120,
+  };
+
   return (
-    <FlipTile
-      className="deck-cover"
-      isFlipped={flippable && flipped}
-      front={getCoverFront()}
-      back={getCoverBack()}
-      onClick={onClickHandler}
-    />
+    <motion.div key={deck.metaData.id} layout transition={springTransition} className="deck-cover">
+      <FlipTile
+        isFlipped={flippable && flipped}
+        front={getCoverFront()}
+        back={getCoverBack()}
+        onClick={onClickHandler}
+      />
+    </motion.div>
   );
 
   function onClickHandler(event: React.MouseEvent) {

--- a/src/pages/decks/flashcard-decks.scss
+++ b/src/pages/decks/flashcard-decks.scss
@@ -30,7 +30,7 @@
     grid-template-columns: repeat(auto-fill, minmax(335px, 1fr));
     justify-items: center;
     grid-auto-rows: max-content;
-    column-gap: 56px;
+    column-gap: 32px;
     row-gap: 32px;
     margin: 32px 0px;
     width: 100%;
@@ -41,6 +41,7 @@
     overflow-y: auto;
 
     .deck-cover:first-child .cover-front {
+      @include standard-transition;
       background-color: $light-blue;
 
       &:hover {


### PR DESCRIPTION
- added deck cover animation when reordered 
- added text color transition for `add new deck` card

https://user-images.githubusercontent.com/39753553/164149673-f2e8e315-db41-4c20-aeb0-793178ca62cd.mov


