### PR TITLE
Add deck nav in search bar

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -4,11 +4,11 @@ import { useState } from 'react';
 import { Sidebar } from './components/sidebar/sidebar';
 import { Header } from './components/header/header';
 import { PageRoutes } from './routes';
-import { userDecksState } from './state/user-decks';
+import { userDecksSortedState } from './state/user-decks';
 import { useRecoilValue } from 'recoil';
 
 function App() {
-  const userDecks = useRecoilValue(userDecksState);
+  const userDecks = useRecoilValue(userDecksSortedState);
 
   return (
     <div className="App">

--- a/src/components/header/header.test.tsx
+++ b/src/components/header/header.test.tsx
@@ -1,14 +1,27 @@
 import React from 'react';
 import { Header } from './header';
-import { render, screen } from '@testing-library/react';
-
-jest.mock('react-router-dom');
+import { fireEvent, screen } from '@testing-library/react';
+import { testEnglishDeck } from '../../models/mock/deck.mock';
+import userEvent from '@testing-library/user-event';
+import { renderWithHistoryRouter } from '../../app.test';
+import { paths } from '../../routes';
 
 describe('Header', () => {
   it('should render correctly with default props', () => {
-    render(<Header decks={[]} />);
+    renderWithHistoryRouter(<Header decks={[]} />);
     expect(screen.queryByText('sign up')).toBeInTheDocument();
     expect(screen.queryByText('sign in')).toBeInTheDocument();
+  });
+
+  it('should route to view deck when dropdown option clicked', () => {
+    const testDeck = testEnglishDeck(0);
+    const { history } = renderWithHistoryRouter(<Header decks={[testDeck]} />);
+
+    // type one letter of test deck title then click dropdown option
+    userEvent.type(screen.getByRole('textbox'), testDeck.metaData.title.substring(0, 1));
+    fireEvent.click(screen.getByText(testDeck.metaData.title));
+
+    expect(history.location.pathname).toBe(`${paths.deck}/${testDeck.metaData.id}`);
   });
 
   // todo: test sign up, sign in button functionality when hooked up

--- a/src/components/header/header.test.tsx
+++ b/src/components/header/header.test.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import { Header } from './header';
 import { render, screen } from '@testing-library/react';
 
+jest.mock('react-router-dom');
+
 describe('Header', () => {
   it('should render correctly with default props', () => {
     render(<Header decks={[]} />);

--- a/src/components/header/header.tsx
+++ b/src/components/header/header.tsx
@@ -3,17 +3,24 @@ import React from 'react';
 import { SearchBar } from '../search-bar/search-bar';
 import { Button } from '../button/button';
 import { Deck } from '../../models/deck';
+import { useNavigate } from 'react-router-dom';
+import { paths } from '../../routes';
 
 interface HeaderProps {
   decks: Deck[];
 }
 
 export const Header = ({ decks }: HeaderProps) => {
+  const navigate = useNavigate();
   return (
     <div className="c-header">
       <div className="c-header-content">
         <div className="c-search-bar-container">
-          <SearchBar placeholder="search my decks" dropDownData={getDeckOptions()} />
+          <SearchBar
+            placeholder="search my decks"
+            dropDownData={getDeckOptions()}
+            onDropdownClick={({ id }) => navigate(`${paths.deck}/${id}`)}
+          />
         </div>
         <div className="c-account-buttons">
           <Button onClick={handleSignUpClick} className="sign-up-button">

--- a/src/components/header/header.tsx
+++ b/src/components/header/header.tsx
@@ -12,6 +12,7 @@ interface HeaderProps {
 
 export const Header = ({ decks }: HeaderProps) => {
   const navigate = useNavigate();
+
   return (
     <div className="c-header">
       <div className="c-header-content">

--- a/src/components/page-header/page-header.test.tsx
+++ b/src/components/page-header/page-header.test.tsx
@@ -5,18 +5,26 @@ import { noop } from '../../helpers/func';
 import userEvent from '@testing-library/user-event';
 
 const TEST_LABEL = 'TEST_LABEL';
+const TEST_GO_BACK_LABEL = 'TEST_GO_BACK_LABEL';
 
 describe('PageHeader', () => {
   it('should render correctly with default props', () => {
-    render(<PageHeader label={TEST_LABEL} onGoBackClick={noop} />);
+    render(<PageHeader label={TEST_LABEL} onGoBackClick={noop} goBackLabel={TEST_GO_BACK_LABEL} />);
     expect(screen.queryByText(TEST_LABEL)).toBeInTheDocument();
+    expect(screen.queryByText(TEST_GO_BACK_LABEL)).toBeInTheDocument();
   });
 
   it('should trigger `onGoBackClick` when button pressed', () => {
     const mockOnGoBackClick = jest.fn();
-    render(<PageHeader label={TEST_LABEL} onGoBackClick={mockOnGoBackClick} />);
+    render(
+      <PageHeader
+        label={TEST_LABEL}
+        onGoBackClick={mockOnGoBackClick}
+        goBackLabel={TEST_GO_BACK_LABEL}
+      />
+    );
 
-    userEvent.click(screen.getByText('back to decks'));
+    userEvent.click(screen.getByText(TEST_GO_BACK_LABEL));
     expect(mockOnGoBackClick).toBeCalled();
   });
 });

--- a/src/components/page-header/page-header.tsx
+++ b/src/components/page-header/page-header.tsx
@@ -5,14 +5,15 @@ import { BackArrowIcon } from '../../assets/icons/back-arrow-icon/back-arrow-ico
 
 interface PageHeaderProps {
   label: string;
+  goBackLabel: string;
   onGoBackClick: (event: React.MouseEvent) => void;
 }
 
-export const PageHeader = ({ label, onGoBackClick }: PageHeaderProps) => {
+export const PageHeader = ({ label, goBackLabel, onGoBackClick }: PageHeaderProps) => {
   return (
     <div className="c-page-header">
       <Button variant="invisible" onClick={onGoBackClick} className="go-back-button">
-        <BackArrowIcon /> back to decks
+        <BackArrowIcon /> {goBackLabel}
       </Button>
       <label>{label}</label>
     </div>

--- a/src/pages/edit-deck-page/deck-editor/deck-editor.test.tsx
+++ b/src/pages/edit-deck-page/deck-editor/deck-editor.test.tsx
@@ -27,10 +27,24 @@ describe('DeckEditor', () => {
     expect(screen.queryByText('edit deck')).toBeInTheDocument();
     expect(screen.queryByText('save')).toBeInTheDocument();
     expect(screen.queryByText('new card')).toBeInTheDocument();
+    expect(screen.queryByText('back to deck')).toBeInTheDocument();
     expect(screen.queryByText('discard changes')).not.toBeInTheDocument();
     expect(
       screen.queryByText('you currently have no cards. click "+ new card" to get started')
     ).toBeInTheDocument();
+  });
+
+  it('should show "go back to decks" when is new deck', () => {
+    render(
+      <DeckEditor
+        initialDeck={createNewDeck()}
+        isNewDeck={true}
+        onCreateDeckClick={noop}
+        onDeleteDeckClick={noop}
+        onGoBackClick={noop}
+      />
+    );
+    expect(screen.queryByText('back to decks')).toBeInTheDocument();
   });
 
   it('should add a new card on click', () => {
@@ -134,7 +148,7 @@ describe('DeckEditor', () => {
         onGoBackClick={mockOnGoBackClick}
       />
     );
-    userEvent.click(screen.getByText('back to decks'));
+    userEvent.click(screen.getByText('back to deck'));
 
     expect(mockOnGoBackClick).toBeCalled();
   });

--- a/src/pages/edit-deck-page/deck-editor/deck-editor.tsx
+++ b/src/pages/edit-deck-page/deck-editor/deck-editor.tsx
@@ -56,7 +56,11 @@ export const DeckEditor = ({
   return (
     <div className="deck-editor">
       <div className="deck-editor-header">
-        <PageHeader label={isNewDeck ? 'create deck' : 'edit deck'} onGoBackClick={onGoBackClick} />
+        <PageHeader
+          label={isNewDeck ? 'create deck' : 'edit deck'}
+          goBackLabel={isNewDeck ? 'back to decks' : 'back to deck'}
+          onGoBackClick={onGoBackClick}
+        />
         <div className="deck-editor-save-buttons">
           {getDiscardChangesButton()}
           <Button

--- a/src/pages/edit-deck-page/edit-deck-page.tsx
+++ b/src/pages/edit-deck-page/edit-deck-page.tsx
@@ -27,7 +27,7 @@ export const EditDeckPage = () => {
     } else {
       fetchDeckAndRefresh();
     }
-  }, [location]);
+  }, [location, deckId]);
 
   if (deck === undefined) {
     return <LoadingPage label="loading deck..." />;
@@ -46,6 +46,7 @@ export const EditDeckPage = () => {
   );
 
   async function fetchDeckAndRefresh() {
+    setDeck(undefined);
     if (deckId === undefined) {
       throw new Error('deckId cannot be undefined');
     }

--- a/src/pages/edit-deck-page/edit-deck-page.tsx
+++ b/src/pages/edit-deck-page/edit-deck-page.tsx
@@ -40,7 +40,7 @@ export const EditDeckPage = () => {
         initialDeck={deck}
         onCreateDeckClick={handleCreateDeckClick}
         onDeleteDeckClick={handleDeleteDeckClick}
-        onGoBackClick={navigateBackToDecks}
+        onGoBackClick={handleGoBackClick}
       />
     </Fade>
   );
@@ -57,7 +57,7 @@ export const EditDeckPage = () => {
   async function handleCreateDeckClick(deck: Deck) {
     const newDeckId = await addDeck(deck);
     await addCards(deck.cards, newDeckId);
-    navigate(`${paths.deck}/${newDeckId}`);
+    navigateToViewDeck(newDeckId);
   }
 
   async function handleDeleteDeckClick() {
@@ -67,7 +67,17 @@ export const EditDeckPage = () => {
     navigateBackToDecks();
   }
 
+  function handleGoBackClick() {
+    !isNewDeck && deck !== undefined
+      ? navigateToViewDeck(deck?.metaData.id)
+      : navigateBackToDecks();
+  }
+
   function navigateBackToDecks() {
     navigate(paths.decks);
+  }
+
+  function navigateToViewDeck(id: number) {
+    navigate(`${paths.deck}/${id}`);
   }
 };

--- a/src/pages/view-deck-page/view-deck-page.tsx
+++ b/src/pages/view-deck-page/view-deck-page.tsx
@@ -21,15 +21,9 @@ export const ViewDeckPage = () => {
   const { getDeckById } = useDecksClient();
   const { getCardsByDeckId } = useCardsClient();
 
-  const isNewDeck = location.pathname === paths.createDeck;
-
   useEffect(() => {
-    if (isNewDeck) {
-      setDeck(createNewDeck());
-    } else {
-      fetchDeckAndRefresh();
-    }
-  }, [location]);
+    fetchDeckAndRefresh();
+  }, [location, deckId]);
 
   if (deck === undefined) {
     return <LoadingPage label="loading deck..." />;
@@ -38,7 +32,11 @@ export const ViewDeckPage = () => {
   return (
     <Fade className="view-deck-page">
       <div className="view-deck-header">
-        <PageHeader label={deck.metaData.title} onGoBackClick={navigateBackToDecks} />
+        <PageHeader
+          label={deck.metaData.title}
+          onGoBackClick={navigateBackToDecks}
+          goBackLabel="back to decks"
+        />
         <div>
           <Button onClick={noop} size="medium">
             study

--- a/src/pages/view-deck-page/view-deck-page.tsx
+++ b/src/pages/view-deck-page/view-deck-page.tsx
@@ -2,7 +2,7 @@ import './view-deck-page.scss';
 import React, { useEffect } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { useDecksClient } from '../../hooks/api/use-decks-client';
-import { createNewDeck, Deck } from '../../models/deck';
+import { Deck } from '../../models/deck';
 import { useCardsClient } from '../../hooks/api/use-cards-client';
 import { LoadingPage } from '../../components/loading-page/loading-page';
 import { useState } from 'react';
@@ -11,7 +11,6 @@ import { paths } from '../../routes';
 import { PageHeader } from '../../components/page-header/page-header';
 import { Button } from '../../components/button/button';
 import { noop } from '../../helpers/func';
-import { BubbleDivider } from '../../components/bubble-divider/bubble-divider';
 import { FlashcardSet } from '../../components/flashcard-set/flashcard-set';
 
 export const ViewDeckPage = () => {
@@ -55,6 +54,7 @@ export const ViewDeckPage = () => {
   );
 
   async function fetchDeckAndRefresh() {
+    setDeck(undefined);
     if (deckId === undefined) {
       throw new Error('deckId cannot be undefined'); // Todo: maybe route to a 404 page??
     }


### PR DESCRIPTION
- added deck nav in the search bar
  - only when a user clicks on a drop-down option
- updated routing so `go back` when editing takes user back to `view deck` for existing decks
  - if new user is taken back to `decks`
- parameterized `go back` label for `PageHeader` component 
- added and fixed tests

https://user-images.githubusercontent.com/39753553/164247982-9f8a8bea-a806-4e3c-917c-98e433c3db9f.mov


