### PR TITLE
fix: use fake timers to resolve flaky dropdown options test

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5596,13 +5596,19 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001312",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001312.tgz",
-      "integrity": "sha512-Wiz1Psk2MEK0pX3rUzWaunLTZzqS2JYZFzNKqAiJGiuxIjRPLgV6+VDPOg6lQOUxmDwhTlh198JsTTi8Hzw6aQ==",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/browserslist"
-      }
+      "version": "1.0.30001383",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001383.tgz",
+      "integrity": "sha512-swMpEoTp5vDoGBZsYZX7L7nXHe6dsHxi9o6/LKf/f0LukVtnrxly5GVb/fWdCDTqi/yw6Km6tiJ0pmBacm0gbg==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        }
+      ]
     },
     "node_modules/capture-exit": {
       "version": "2.0.0",
@@ -23329,9 +23335,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001312",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001312.tgz",
-      "integrity": "sha512-Wiz1Psk2MEK0pX3rUzWaunLTZzqS2JYZFzNKqAiJGiuxIjRPLgV6+VDPOg6lQOUxmDwhTlh198JsTTi8Hzw6aQ=="
+      "version": "1.0.30001383",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001383.tgz",
+      "integrity": "sha512-swMpEoTp5vDoGBZsYZX7L7nXHe6dsHxi9o6/LKf/f0LukVtnrxly5GVb/fWdCDTqi/yw6Km6tiJ0pmBacm0gbg=="
     },
     "capture-exit": {
       "version": "2.0.0",

--- a/src/components/drop-down-options/drop-down-options.test.tsx
+++ b/src/components/drop-down-options/drop-down-options.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { DropDownOption, DropDownOptions } from './drop-down-options';
-import { render, screen, waitForElementToBeRemoved } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { noop } from '../../helpers/func';
 import {
@@ -9,6 +9,7 @@ import {
   TEST_OPTIONS_SMALL,
   TEST_OPTIONS_SMALL_VALUES,
 } from './options.mock';
+import { withFakeTimers } from '../../helpers/test';
 
 describe('Button', () => {
   it('should render correctly with default props', () => {
@@ -16,15 +17,20 @@ describe('Button', () => {
     expect(screen.queryByText(TEST_OPTIONS_SINGLE_VALUES[0])).toBeVisible();
   });
 
-  it('should hide when component rerenders with show as false', async () => {
-    const { rerender } = render(
-      <DropDownOptions show={true} options={TEST_OPTIONS_SINGLE} onOptionSelect={noop} />
-    );
-    expect(screen.queryByText(TEST_OPTIONS_SINGLE_VALUES[0])).toBeVisible();
+  it('should hide when component rerenders with show as false', () => {
+    return withFakeTimers(async () => {
+      const { rerender } = render(
+        <DropDownOptions show={true} options={TEST_OPTIONS_SINGLE} onOptionSelect={noop} />
+      );
+      expect(screen.queryByText(TEST_OPTIONS_SINGLE_VALUES[0])).toBeVisible();
 
-    rerender(<DropDownOptions show={false} options={TEST_OPTIONS_SINGLE} onOptionSelect={noop} />);
-    await waitForElementToBeRemoved(() => screen.queryByText(TEST_OPTIONS_SINGLE_VALUES[0]), {
-      timeout: 1000, // wrt `Fade` having transition duration of 0.2 (200ms)
+      rerender(
+        <DropDownOptions show={false} options={TEST_OPTIONS_SINGLE} onOptionSelect={noop} />
+      );
+
+      // wrt `Fade` having transition duration of 0.2 (200ms)
+      jest.advanceTimersByTime(208); // 16 * Math.ceil(200 / 16)
+      expect(screen.queryByText(TEST_OPTIONS_SINGLE_VALUES[0])).not.toBeVisible();
     });
   });
 

--- a/src/components/search-bar/search-bar.test.tsx
+++ b/src/components/search-bar/search-bar.test.tsx
@@ -152,7 +152,7 @@ describe('SearchBar', () => {
     );
     const input = getSearchBarInput(container);
 
-    // type the word 'test' character by chararacter
+    // type the word 'test' character by character
     userEvent.type(input, 'test');
     await waitFor(() => expect(mockOnDebouncedChange).toBeCalledWith('test'), { timeout: 500 });
   });

--- a/src/helpers/test.ts
+++ b/src/helpers/test.ts
@@ -1,0 +1,13 @@
+/**
+ * Block level method that installs fake timers for the test callback and uninstalls it after.
+ * @param testCallback the test function that can have async calls
+ */
+export async function withFakeTimers(testCallback: () => Promise<void> | void) {
+  jest.useFakeTimers();
+  try {
+    await testCallback();
+  } finally {
+    jest.runOnlyPendingTimers(); // could use runAllTimers but this can get stuck if a task indefinitely schedules more macrotasks
+    jest.useRealTimers();
+  }
+}


### PR DESCRIPTION
title; it also speeds up tests bc we no longer have to wait for `rAF` so win-win situation