### PR TITLE
added stricter typing to dropdown menu

### DIFF
--- a/src/components/drop-down-options/drop-down-options.test.tsx
+++ b/src/components/drop-down-options/drop-down-options.test.tsx
@@ -40,7 +40,7 @@ describe('Button', () => {
       <DropDownOptions
         show={true}
         options={TEST_OPTIONS_SMALL}
-        onOptionSelect={(option: DropDownOption) => mockOnOptionSelect(option.value)}
+        onOptionSelect={(option: DropDownOption<string>) => mockOnOptionSelect(option.value)}
       />
     );
 

--- a/src/components/drop-down-options/drop-down-options.tsx
+++ b/src/components/drop-down-options/drop-down-options.tsx
@@ -4,24 +4,24 @@ import { Button } from '../button/button';
 import { Fade } from '../../animations/fade';
 import { AnimatePresence } from 'framer-motion';
 
-export interface DropDownOption {
+export interface DropDownOption<T> {
   id: string;
-  value: React.ReactNode;
+  value: T;
 }
 
-interface DropDownOptionsProps {
+interface DropDownOptionsProps<T> {
   className?: string;
   show: boolean;
-  options?: DropDownOption[];
-  onOptionSelect: (option: DropDownOption) => void;
+  options?: DropDownOption<T>[];
+  onOptionSelect: (option: DropDownOption<T>) => void;
 }
 
-export const DropDownOptions = ({
+export const DropDownOptions = <T extends React.ReactNode>({
   className = '',
   show,
   options,
   onOptionSelect,
-}: DropDownOptionsProps) => {
+}: DropDownOptionsProps<T>) => {
   return (
     <AnimatePresence>
       {show && options !== undefined && (

--- a/src/components/drop-down-options/options.mock.ts
+++ b/src/components/drop-down-options/options.mock.ts
@@ -1,25 +1,24 @@
-import { getValue } from '@testing-library/user-event/dist/utils';
 import { DropDownOption } from './drop-down-options';
 
 // 0-indexed, (size = 1) generates [{id: 'test0', value: 'test0'}]
-export const createTestOptions = (size: number): DropDownOption[] =>
+export const createTestOptions = (size: number): DropDownOption<string>[] =>
   [...Array(size)].map((_, index) => ({
     id: `test${index}`,
     value: `test${index}`,
   }));
 
-export const TEST_OPTIONS_SINGLE: DropDownOption[] = createTestOptions(1);
-export const TEST_OPTIONS_SINGLE_VALUES: string[] = TEST_OPTIONS_SINGLE.map(getValueAsString);
+export const TEST_OPTIONS_SINGLE: DropDownOption<string>[] = createTestOptions(1);
+export const TEST_OPTIONS_SINGLE_VALUES: string[] = TEST_OPTIONS_SINGLE.map(getValue);
 
-export const TEST_OPTIONS_SMALL: DropDownOption[] = createTestOptions(10);
-export const TEST_OPTIONS_SMALL_VALUES: string[] = TEST_OPTIONS_SMALL.map(getValueAsString);
+export const TEST_OPTIONS_SMALL: DropDownOption<string>[] = createTestOptions(10);
+export const TEST_OPTIONS_SMALL_VALUES: string[] = TEST_OPTIONS_SMALL.map(getValue);
 
-export const TEST_OPTIONS_MEDIUM: DropDownOption[] = createTestOptions(100);
-export const TEST_OPTIONS_MEDIUM_VALUES: string[] = TEST_OPTIONS_MEDIUM.map(getValueAsString);
+export const TEST_OPTIONS_MEDIUM: DropDownOption<string>[] = createTestOptions(100);
+export const TEST_OPTIONS_MEDIUM_VALUES: string[] = TEST_OPTIONS_MEDIUM.map(getValue);
 
-export const TEST_OPTIONS_LARGE: DropDownOption[] = createTestOptions(1000);
-export const TEST_OPTIONS_LARGE_VALUES: string[] = TEST_OPTIONS_LARGE.map(getValueAsString);
+export const TEST_OPTIONS_LARGE: DropDownOption<string>[] = createTestOptions(1000);
+export const TEST_OPTIONS_LARGE_VALUES: string[] = TEST_OPTIONS_LARGE.map(getValue);
 
-function getValueAsString(option: DropDownOption) {
-  return option.value as string;
+function getValue(option: DropDownOption<string>) {
+  return option.value;
 }

--- a/src/components/drop-down/drop-down.tsx
+++ b/src/components/drop-down/drop-down.tsx
@@ -7,23 +7,23 @@ import { useOutsideClick } from '../../hooks/use-outside-click';
 import { useFocusTrap } from '../../hooks/use-focus-trap';
 import { DropDownOption, DropDownOptions } from '../drop-down-options/drop-down-options';
 
-interface DropDownProps {
+interface DropDownProps<T> {
   variant?: 'dark' | 'light';
   label?: React.ReactNode;
   className?: string;
-  options: DropDownOption[];
+  options: DropDownOption<T>[];
   buttonLabel: React.ReactNode;
-  onOptionSelect: (option: DropDownOption) => void;
+  onOptionSelect: (option: DropDownOption<T>) => void;
 }
 
-export const DropDown = ({
+export const DropDown = <T extends React.ReactNode>({
   variant = 'dark',
   label = '',
   className = '',
   options,
   buttonLabel,
   onOptionSelect,
-}: DropDownProps) => {
+}: DropDownProps<T>) => {
   const [isOpen, setIsOpen] = useState(false);
   const accentVariant = variant === 'dark' ? 'light' : 'dark';
 
@@ -50,7 +50,7 @@ export const DropDown = ({
     );
   }
 
-  function handleOptionSelect(option: DropDownOption) {
+  function handleOptionSelect(option: DropDownOption<T>) {
     onOptionSelect(option);
     setIsOpen(false);
   }

--- a/src/components/flashcard/card-face/card-face.tsx
+++ b/src/components/flashcard/card-face/card-face.tsx
@@ -41,7 +41,7 @@ export const CardFace = ({
       {isReadonly && hasText && getSpeaker()}
       {variant === 'active' && (
         <CardMenu
-          language={cardContent.language as any}
+          language={cardContent.language}
           changeLanguageLabel={changeLanguageLabel ?? ''}
           swapContentLabel={swapContentLabel ?? ''}
           onLanguageChange={handleLanguageChange}

--- a/src/components/header/header.tsx
+++ b/src/components/header/header.tsx
@@ -5,6 +5,7 @@ import { Button } from '../button/button';
 import { Deck } from '../../models/deck';
 import { useNavigate } from 'react-router-dom';
 import { paths } from '../../routes';
+import { DropDownOption } from '../drop-down-options/drop-down-options';
 
 interface HeaderProps {
   decks: Deck[];
@@ -35,7 +36,7 @@ export const Header = ({ decks }: HeaderProps) => {
     </div>
   );
 
-  function getDeckOptions() {
+  function getDeckOptions(): DropDownOption<string>[] {
     return decks.map((deck) => ({ id: deck.metaData.id.toString(), value: deck.metaData.title }));
   }
 

--- a/src/components/language-drop-down/drop-down-options/language-drop-down.tsx
+++ b/src/components/language-drop-down/drop-down-options/language-drop-down.tsx
@@ -40,8 +40,8 @@ export const LanguageDropDown = <T extends DeckLanguages | CardLanguages>({
     </div>
   );
 
-  function handleOptionSelect(option: DropDownOption) {
-    const newLanguage = option.value as T[number];
+  function handleOptionSelect(option: DropDownOption<T[number]>) {
+    const newLanguage = option.value;
     onLanguageSelect(newLanguage);
   }
 };

--- a/src/components/search-bar/search-bar.tsx
+++ b/src/components/search-bar/search-bar.tsx
@@ -101,9 +101,6 @@ export const SearchBar = ({
   }
 
   function optionIncludesValueFilter(option: DropDownOption<string>) {
-    if (typeof option.value !== 'string') {
-      return false;
-    }
     const optionVal = option.value;
     const searchVal = value.trim();
     return dropDownIgnoreCase

--- a/src/components/search-bar/search-bar.tsx
+++ b/src/components/search-bar/search-bar.tsx
@@ -13,13 +13,13 @@ export interface SearchBarProps {
   initialText?: string;
   placeholder?: string;
   disabled?: boolean;
-  dropDownData?: DropDownOption[];
+  dropDownData?: DropDownOption<string>[];
   dropDownIgnoreCase?: boolean;
   debounceMs?: number;
   onChange?: (value: string) => void;
   onEnterPressed?: (value: string) => void;
   onDebouncedChange?: (value: string) => void;
-  onDropdownClick?: (option: DropDownOption) => void;
+  onDropdownClick?: (option: DropDownOption<string>) => void;
 }
 
 export const SearchBar = ({
@@ -100,7 +100,7 @@ export const SearchBar = ({
     );
   }
 
-  function optionIncludesValueFilter(option: DropDownOption) {
+  function optionIncludesValueFilter(option: DropDownOption<string>) {
     if (typeof option.value !== 'string') {
       return false;
     }

--- a/src/pages/decks/flashcard-decks.tsx
+++ b/src/pages/decks/flashcard-decks.tsx
@@ -1,9 +1,7 @@
 import React, { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
-import { Button } from '../../components/button/button';
 import { DeckCover } from '../../components/deck-cover/deck-cover';
-import { DropDownOption } from '../../components/drop-down-options/drop-down-options';
 import { DropDown } from '../../components/drop-down/drop-down';
 import { noop } from '../../helpers/func';
 import { useDecksClient } from '../../hooks/api/use-decks-client';
@@ -13,8 +11,7 @@ import {
   userDecksState,
   userDecksSortRuleState,
   userDecksSortedState,
-  SortRule,
-  SortRules,
+  AllSortRules,
 } from '../../state/user-decks';
 import './flashcard-decks.scss';
 
@@ -43,10 +40,10 @@ export const FlashcardDecksPage = () => {
         <label>flashcard decks</label>
         <DropDown
           variant="dark"
-          options={SortRules.map((item) => ({ id: item, value: item }))}
+          options={AllSortRules.map((item) => ({ id: item, value: item }))}
           label="sort by"
           buttonLabel={sortOption}
-          onOptionSelect={(option: DropDownOption) => setSortOption(option.value as SortRule)}
+          onOptionSelect={(option) => setSortOption(option.value)}
         />
       </div>
       <div className="deck-tile-container">

--- a/src/state/user-decks.ts
+++ b/src/state/user-decks.ts
@@ -9,14 +9,17 @@ export const userDecksState = atom<Deck[]>({
   default: [testEnglishDeck(0)],
 });
 
-export const SortRules = [
+export const AllSortRules = [
   'sequential',
   'last created',
   'last updated',
   'last studied',
   'random',
 ] as const;
-export type SortRule = typeof SortRules[number];
+
+export type SortRules = typeof AllSortRules;
+
+export type SortRule = SortRules[number];
 
 // mutatable: sort order
 export const userDecksSortRuleState = atom<SortRule>({


### PR DESCRIPTION
Added stricter typing to the dropdowns. 

onOptionSelect can now infer the type from the given options. 

For arrays declared as const for the options, the type is exactly one of the provided options. 

If the options type is not strict (e.g. string[]) the option type will also be not strict (string following the example). 


