### PR TITLE
feat: fetch with auth-jwt headers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
         "eslint-plugin-prettier": "^4.0.0",
         "eslint-plugin-react": "^7.29.2",
         "eslint-plugin-simple-import-sort": "^7.0.0",
+        "jest-fetch-mock": "^3.0.3",
         "jest-watch-typeahead": "^0.6.5",
         "prettier": "^2.5.1",
         "sass": "^1.54.5",
@@ -5948,6 +5949,15 @@
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "devOptional": true
     },
+    "node_modules/cross-fetch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
+      "integrity": "sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==",
+      "dev": true,
+      "dependencies": {
+        "node-fetch": "2.6.7"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -11004,6 +11014,16 @@
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
     },
+    "node_modules/jest-fetch-mock": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/jest-fetch-mock/-/jest-fetch-mock-3.0.3.tgz",
+      "integrity": "sha512-Ux1nWprtLrdrH4XwE7O7InRY6psIi3GOsqNESJgMJ+M5cv4A8Lh7SN9d2V2kKRZ8ebAfcd1LNyZguAOb6JiDqw==",
+      "dev": true,
+      "dependencies": {
+        "cross-fetch": "^3.0.4",
+        "promise-polyfill": "^8.1.3"
+      }
+    },
     "node_modules/jest-get-type": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-27.5.1.tgz",
@@ -12878,6 +12898,48 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
       "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+    },
+    "node_modules/node-fetch": {
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "dev": true,
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-fetch/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "dev": true
+    },
+    "node_modules/node-fetch/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "dev": true
+    },
+    "node_modules/node-fetch/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dev": true,
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
     },
     "node_modules/node-forge": {
       "version": "1.3.1",
@@ -14874,6 +14936,12 @@
       "dependencies": {
         "asap": "~2.0.6"
       }
+    },
+    "node_modules/promise-polyfill": {
+      "version": "8.2.3",
+      "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-8.2.3.tgz",
+      "integrity": "sha512-Og0+jCRQetV84U8wVjMNccfGCnMQ9mGs9Hv78QFe+pSDD3gWTpz0y+1QCuxy5d/vBFuZ3iwP2eycAkvqIMPmWg==",
+      "dev": true
     },
     "node_modules/prompts": {
       "version": "2.4.2",
@@ -23499,6 +23567,15 @@
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "devOptional": true
     },
+    "cross-fetch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
+      "integrity": "sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==",
+      "dev": true,
+      "requires": {
+        "node-fetch": "2.6.7"
+      }
+    },
     "cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -27171,6 +27248,16 @@
         "jest-util": "^27.5.1"
       }
     },
+    "jest-fetch-mock": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/jest-fetch-mock/-/jest-fetch-mock-3.0.3.tgz",
+      "integrity": "sha512-Ux1nWprtLrdrH4XwE7O7InRY6psIi3GOsqNESJgMJ+M5cv4A8Lh7SN9d2V2kKRZ8ebAfcd1LNyZguAOb6JiDqw==",
+      "dev": true,
+      "requires": {
+        "cross-fetch": "^3.0.4",
+        "promise-polyfill": "^8.1.3"
+      }
+    },
     "jest-get-type": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-27.5.1.tgz",
@@ -28501,6 +28588,39 @@
         }
       }
     },
+    "node-fetch": {
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "dev": true,
+      "requires": {
+        "whatwg-url": "^5.0.0"
+      },
+      "dependencies": {
+        "tr46": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+          "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+          "dev": true
+        },
+        "webidl-conversions": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+          "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+          "dev": true
+        },
+        "whatwg-url": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+          "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+          "dev": true,
+          "requires": {
+            "tr46": "~0.0.3",
+            "webidl-conversions": "^3.0.0"
+          }
+        }
+      }
+    },
     "node-forge": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
@@ -29823,6 +29943,12 @@
       "requires": {
         "asap": "~2.0.6"
       }
+    },
+    "promise-polyfill": {
+      "version": "8.2.3",
+      "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-8.2.3.tgz",
+      "integrity": "sha512-Og0+jCRQetV84U8wVjMNccfGCnMQ9mGs9Hv78QFe+pSDD3gWTpz0y+1QCuxy5d/vBFuZ3iwP2eycAkvqIMPmWg==",
+      "dev": true
     },
     "prompts": {
       "version": "2.4.2",

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "eslint-plugin-prettier": "^4.0.0",
     "eslint-plugin-react": "^7.29.2",
     "eslint-plugin-simple-import-sort": "^7.0.0",
+    "jest-fetch-mock": "^3.0.3",
     "jest-watch-typeahead": "^0.6.5",
     "prettier": "^2.5.1",
     "sass": "^1.54.5",

--- a/src/app.test.tsx
+++ b/src/app.test.tsx
@@ -3,6 +3,7 @@ import { unstable_HistoryRouter as HistoryRouter } from 'react-router-dom';
 import { render, screen } from '@testing-library/react';
 import { createMemoryHistory } from 'history';
 import { RecoilRoot } from 'recoil';
+import { initRecoilState } from './state/init';
 import App from './app';
 
 export function renderWithHistoryRouter(
@@ -13,6 +14,10 @@ export function renderWithHistoryRouter(
     history,
     ...render(<HistoryRouter history={history}>{jsxElement}</HistoryRouter>),
   };
+}
+
+export function renderWithRecoilRoot(jsxElement: JSX.Element) {
+  return render(<RecoilRoot initializeState={initRecoilState}>{jsxElement}</RecoilRoot>);
 }
 
 test('renders learn react link', () => {

--- a/src/helpers/tests/validator.test.ts
+++ b/src/helpers/tests/validator.test.ts
@@ -1,0 +1,50 @@
+import { isObject, objectSchemaSimple } from '../validator';
+
+describe('validator', () => {
+  it('should type-guard that subject is an object iff it is a js object', () => {
+    const jsObject = { someKey: 'someValue' };
+    expect(isObject(jsObject)).toBe(true);
+
+    const jsArray = ['should', 'not', 'pass', 'validator'];
+    expect(isObject(jsArray)).toBe(false);
+
+    // typeof null === 'object' is true for reasons you don't want to know
+    expect(isObject(null)).toBe(false);
+  });
+
+  it('should type-guard if an object passes a simple schema validator', () => {
+    interface TestError {
+      errorNumber: number;
+      message: string;
+      errorObject: Error;
+    }
+
+    // we are testing this validator
+    const isTestError = objectSchemaSimple<TestError>({
+      errorNumber: 'number',
+      message: 'string',
+      errorObject: 'object',
+    });
+
+    // fine
+    const testError = {
+      errorNumber: 1,
+      message: 'oops',
+      errorObject: new Error('hi!'),
+    };
+    expect(isTestError(testError)).toBe(true);
+
+    // fine
+    const testErrorWithMore = {
+      ...testError,
+      extra: 'hello there',
+    };
+    expect(isTestError(testErrorWithMore)).toBe(true);
+
+    // not fine
+    const notTestError = {
+      message: 'not enough info!',
+    };
+    expect(isTestError(notTestError)).toBe(false);
+  });
+});

--- a/src/helpers/validator.ts
+++ b/src/helpers/validator.ts
@@ -1,0 +1,26 @@
+/**
+ * Creates a user-type guard for objects provided a simple key-to-type schema.
+ * Optional (?) types should not be provided in the simple schema.
+ *
+ * @param schema - (e.g.) { 'message': 'string', 'id': 'number' }
+ */
+export function objectSchemaSimple<T extends object>(schema: Record<string, string>) {
+  return (subject: unknown): subject is T => {
+    if (!isObject(subject)) {
+      return false;
+    }
+
+    return Object.entries(schema).every(([key, expectedType]) => {
+      const value = subject[key];
+      return value && typeof value === expectedType;
+    });
+  };
+}
+
+export function isObject(subject: unknown): subject is Record<string, unknown> {
+  return subject !== null && typeof subject === 'object' && !Array.isArray(subject);
+}
+
+export function isString(subject: unknown): subject is string {
+  return typeof subject === 'string';
+}

--- a/src/hooks/api/use-fetch-wrapper.ts
+++ b/src/hooks/api/use-fetch-wrapper.ts
@@ -1,11 +1,26 @@
+import { useRecoilValue } from 'recoil';
+import { ECHOSTUDY_API_URL } from '../../helpers/api';
+import { objectSchemaSimple } from '../../helpers/validator';
+import { oauth2JwtState } from '../../state/oauth2-jwt';
+
+export interface FetchError {
+  statusCode: number;
+  message: string;
+}
+
+export const isFetchError = objectSchemaSimple<FetchError>({
+  statusCode: 'number',
+  message: 'string',
+});
+
 /**
- * fetch() wrapper with useful helper functions
+ * Fetch wrapper that handles user authentication and automatic token renewal per request.
+ * highly inspired by: https://jasonwatmore.com/post/2021/09/07/react-recoil-jwt-authentication-tutorial-and-example
  *
  * @param prependApiUrl url to prepend to all requests
  */
 export function useFetchWrapper(prependApiUrl?: string) {
-  // https://jasonwatmore.com/post/2021/09/07/react-recoil-jwt-authentication-tutorial-and-example
-  /* eslint-disable @typescript-eslint/no-unused-vars */
+  const authJwt = useRecoilValue(oauth2JwtState);
 
   return {
     get: request('GET'),
@@ -15,18 +30,8 @@ export function useFetchWrapper(prependApiUrl?: string) {
   };
 
   function request(method: string) {
-    return async function (url: string, body?: object) {
-      // only include header if `body` is non-empty
-      const contentTypeHeader = body ? { 'Content-Type': 'application/json' } : undefined;
-      const resolvedUrl = prependApiUrl ? prependApiUrl + url : url;
-
-      const response = await fetch(resolvedUrl, {
-        method: method,
-        headers: { ...contentTypeHeader }, // todo: use auth header which includes JWT
-        body: body && JSON.stringify(body),
-      });
-
-      return await handleResponse(response);
+    return async function (url: string, body?: object, numRetries = 1) {
+      return _retryFetch(url, method, body, numRetries);
     };
   }
 
@@ -34,22 +39,63 @@ export function useFetchWrapper(prependApiUrl?: string) {
   /// helper functions ///
   ////////////////////////
 
-  async function handleResponse(response: Response) {
+  async function _retryFetch(
+    url: string,
+    method: string,
+    body: object | undefined,
+    retries = 1
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ): Promise<any> {
+    const maybeContentTypeHeader = body ? { 'Content-Type': 'application/json' } : undefined;
+    const resolvedUrl = prependApiUrl ? prependApiUrl + url : url;
+    const response = await fetch(resolvedUrl, {
+      method: method,
+      headers: {
+        ...maybeContentTypeHeader,
+        ...authHeader(resolvedUrl),
+      },
+      body: body ? JSON.stringify(body) : undefined,
+    });
+
+    if (response.ok) {
+      return parseResponseForText(response);
+    } else {
+      const statusCode = response.status;
+      switch (statusCode) {
+        // jwt expired
+        case 401:
+          // TODO: refresh token before retrying
+          break;
+
+        default:
+          const retriesLeft = retries - 1;
+          if (retriesLeft < 0) {
+            const error: FetchError = {
+              statusCode,
+              message: `Received ${statusCode} when trying to reach ${url}`,
+            };
+            return Promise.reject(error);
+          }
+          return _retryFetch(url, method, body, retriesLeft);
+      }
+    }
+  }
+
+  /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+  async function parseResponseForText(response: Response): Promise<any> {
     const text = await response.text();
     const data = text && JSON.parse(text);
-
-    if (!response.ok) {
-      // todo: handle 401/403 for user auth, verify JWT token, if not redirect to /login
-      const error = data?.message ?? response.statusText;
-      console.error(error);
-      return Promise.reject(error);
-    }
-
     return data;
   }
 
   function authHeader(url: string): Record<string, string> {
-    // todo: return auth header with jwt if user is logged in and request is to the api url
-    throw new Error('Not implemented');
+    const isEchoStudyApiUrl = url.startsWith(ECHOSTUDY_API_URL);
+
+    if (authJwt && isEchoStudyApiUrl) {
+      const accessToken = authJwt.accessToken;
+      return { Authorization: `Bearer ${accessToken}` };
+    }
+
+    return {};
   }
 }

--- a/src/hooks/api/use-user-client.ts
+++ b/src/hooks/api/use-user-client.ts
@@ -1,0 +1,57 @@
+import { useSetRecoilState } from 'recoil';
+import { isFetchError, useFetchWrapper } from './use-fetch-wrapper';
+import { ECHOSTUDY_API_URL } from '../../helpers/api';
+import { LocalStorageKeys } from '../../state/init';
+import { oauth2JwtState } from '../../state/oauth2-jwt';
+import { useLocalStorage } from '../use-local-storage';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/no-unused-vars */
+
+/**
+ * Client targetting endpoints for user related actions
+ */
+export function useUserClient() {
+  const setAuthJwt = useSetRecoilState(oauth2JwtState);
+  const fetchWrapper = useFetchWrapper(ECHOSTUDY_API_URL);
+  const simpleLocalStorage = useLocalStorage();
+
+  return {
+    login,
+    logout,
+  };
+
+  // POST: /Authenticate
+  // Returns false if an error occurred or the user credentials were incorrect.
+  async function login(username: string, password: string): Promise<boolean> {
+    const payload = {
+      usename: username,
+      password: password,
+    };
+    const numRetries = 0; // don't retry; 401 means incorrect user creds
+
+    try {
+      // TODO: when token refreshing is implemented, this should probably be an object
+      // that contains both the access token as well as the refresh token
+      const { accessToken } = await fetchWrapper.post('/Authenticate', payload, numRetries);
+      const authJwt = {
+        accessToken: accessToken,
+        refreshToken: undefined,
+      };
+      simpleLocalStorage.upsert(LocalStorageKeys.authJwt, authJwt);
+      setAuthJwt(authJwt);
+    } catch (error) {
+      if (isFetchError(error)) {
+        console.error(error.message);
+      }
+      return false;
+    }
+
+    return true;
+  }
+
+  async function logout() {
+    // TODO: inform server to probably invalidate access token
+    throw new Error('logout not implemented');
+  }
+}

--- a/src/hooks/tests/use-fetch-wrapper.test.tsx
+++ b/src/hooks/tests/use-fetch-wrapper.test.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { renderHook } from '@testing-library/react-hooks';
+import { enableFetchMocks } from 'jest-fetch-mock';
+import { RecoilRoot } from 'recoil';
+import { isFetchError, useFetchWrapper } from '../api/use-fetch-wrapper';
+
+// provide fetchMock global and disable mocking initially
+enableFetchMocks();
+fetchMock.dontMock();
+
+describe('useFetchWrapper', () => {
+  // TEST_DOMAIN must be used, otherwise response is not mocked
+  const TEST_DOMAIN = 'https://test.test';
+  beforeEach(() => {
+    fetchMock.doMockIf(/^https?:\/\/test.test.*$/);
+  });
+
+  it('should return response if received 200 (OK)', async () => {
+    const fetchWrapper = setupFetchWrapper();
+
+    fetchMock.mockResponseOnce(JSON.stringify({ data: '12345' }));
+    const response = await fetchWrapper.get('/12345');
+    expect(response.data).toBe('12345');
+  });
+
+  it('should respect numRetries if not 200 (OK)', async () => {
+    const fetchWrapper = setupFetchWrapper();
+
+    const error = JSON.stringify({ error: 'key expired' });
+    const good = JSON.stringify({ data: '12345' });
+    fetchMock.mockResponses(
+      [error, { status: 401 }], // initial
+      [good, { status: 200 }] // first retry
+    );
+
+    const numRetries = 1;
+    const response = await fetchWrapper.get('/12345', undefined, numRetries);
+    expect(response.data).toBe('12345');
+  });
+
+  it('should not retry past numRetries if not 200 (OK)', async () => {
+    const fetchWrapper = setupFetchWrapper();
+
+    const error = JSON.stringify({ error: 'error' });
+    fetchMock.mockResponse(error, { status: 500 }); // never 200
+
+    const numRetries = 20;
+    const fetchPromise = fetchWrapper.get('/12345', undefined, numRetries);
+    await expect(fetchPromise).rejects.toMatchPredicate(isFetchError);
+  });
+
+  function setupFetchWrapper() {
+    const { result } = renderHook(() => useFetchWrapper(TEST_DOMAIN), {
+      wrapper: ({ children }) => <RecoilRoot>{children}</RecoilRoot>,
+    });
+    return result.current;
+  }
+});

--- a/src/hooks/use-local-storage.ts
+++ b/src/hooks/use-local-storage.ts
@@ -1,0 +1,56 @@
+import { isObject, isString } from '../helpers/validator';
+
+/**
+ * Provides a simple interface to browser local storage with added support for:
+ *   - built-in serialization and deserialization
+ *
+ * NOTE: Local storage changes are one to the window (tab).
+ * If cross-tab changes need to be detected, you can subscribe to window's 'storage' event.
+ *
+ */
+export function useLocalStorage() {
+  return {
+    getObject,
+    getString,
+    upsert,
+    remove,
+  };
+
+  function getString(key: string): string | undefined {
+    return localStorage.getItem(key) ?? undefined;
+  }
+
+  function getObject<T extends object>(key: string): T | undefined {
+    const data = localStorage.getItem(key);
+    return data ? (JSON.parse(data) as T) : undefined;
+  }
+
+  function upsert(key: string, value: string | object): boolean {
+    try {
+      // value was an object
+      if (isObject(value)) {
+        const serializedValue = JSON.stringify(value);
+        localStorage.setItem(key, serializedValue);
+        return true;
+      }
+      // value was a string
+      else if (isString(value)) {
+        localStorage.setItem(key, value);
+        return true;
+      }
+      // value was anything else
+      else {
+        return false;
+      }
+    } catch {
+      // potentially QuotaExceededError (storage full)
+      // or the user-agent disabled local storage
+      // regardless, we discard the error and return false for now
+      return false;
+    }
+  }
+
+  function remove(key: string): void {
+    localStorage.removeItem(key);
+  }
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import { BrowserRouter } from 'react-router-dom';
 import { RecoilRoot } from 'recoil';
+import { initRecoilState } from './state/init';
 import App from './app';
 import reportWebVitals from './reportWebVitals';
 import './index.scss';
@@ -9,7 +10,7 @@ import './index.scss';
 ReactDOM.render(
   <React.StrictMode>
     <BrowserRouter>
-      <RecoilRoot>
+      <RecoilRoot initializeState={initRecoilState}>
         <App />
       </RecoilRoot>
     </BrowserRouter>

--- a/src/jest.d.ts
+++ b/src/jest.d.ts
@@ -1,0 +1,5 @@
+declare namespace jest {
+  interface Matchers<R> {
+    toMatchPredicate(predicate: (received: unknown) => Promise<boolean> | boolean): R;
+  }
+}

--- a/src/pages/edit-deck-page/deck-editor/deck-editor.test.tsx
+++ b/src/pages/edit-deck-page/deck-editor/deck-editor.test.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
-import { render, screen, waitForElementToBeRemoved } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { RecoilRoot } from 'recoil';
 import { DeckEditor } from './deck-editor';
+import { renderWithRecoilRoot } from '../../../app.test';
 import { noop } from '../../../helpers/func';
 import { createNewDeck } from '../../../models/deck';
 import { testEnglishDeck } from '../../../models/mock/deck.mock';
@@ -15,7 +17,7 @@ describe('DeckEditor', () => {
   });
 
   it('should render correctly with default props', () => {
-    render(
+    renderWithRecoilRoot(
       <DeckEditor
         initialDeck={createNewDeck()}
         isNewDeck={false}
@@ -35,7 +37,7 @@ describe('DeckEditor', () => {
   });
 
   it('should show "go back to decks" when is new deck', () => {
-    render(
+    renderWithRecoilRoot(
       <DeckEditor
         initialDeck={createNewDeck()}
         isNewDeck={true}
@@ -48,7 +50,7 @@ describe('DeckEditor', () => {
   });
 
   it('should add a new card on click', () => {
-    render(
+    renderWithRecoilRoot(
       <DeckEditor
         initialDeck={createNewDeck()}
         isNewDeck={false}
@@ -65,7 +67,7 @@ describe('DeckEditor', () => {
   });
 
   it('should display discard changes button when deck is not saved', () => {
-    render(
+    renderWithRecoilRoot(
       <DeckEditor
         initialDeck={createNewDeck()}
         isNewDeck={false}
@@ -79,7 +81,7 @@ describe('DeckEditor', () => {
   });
 
   it('should call discard changes on discard changes click', () => {
-    render(
+    renderWithRecoilRoot(
       <DeckEditor
         initialDeck={createNewDeck()}
         isNewDeck={false}
@@ -101,7 +103,7 @@ describe('DeckEditor', () => {
 
   // Todo: fix API calls in hook method and uncomment
   // it('should hide discard changes button on save', async () => {
-  //   render(
+  //   renderWithRecoilRoot(
   //     <DeckEditor
   //       initialDeck={createNewDeck()}
   //       isNewDeck={false}
@@ -122,7 +124,7 @@ describe('DeckEditor', () => {
 
   it('should call onDeleteDeckClick when delete deck is clicked', () => {
     const mockOnDeleteDeckClick = jest.fn();
-    render(
+    renderWithRecoilRoot(
       <DeckEditor
         initialDeck={createNewDeck()}
         isNewDeck={false}
@@ -139,7 +141,7 @@ describe('DeckEditor', () => {
 
   it('should call onGoBackClick when go back is clicked', () => {
     const mockOnGoBackClick = jest.fn();
-    render(
+    renderWithRecoilRoot(
       <DeckEditor
         initialDeck={createNewDeck()}
         isNewDeck={false}
@@ -158,7 +160,7 @@ describe('DeckEditor', () => {
     const deck = createNewDeck();
     deck.metaData.title = 'TEST_TITLE';
     deck.metaData.desc = 'TEST_DESC';
-    render(
+    renderWithRecoilRoot(
       <DeckEditor
         initialDeck={deck}
         isNewDeck={true}
@@ -174,7 +176,7 @@ describe('DeckEditor', () => {
 
   it('should call disable create button when title is empty', () => {
     const mockOnCreateDeckClick = jest.fn();
-    render(
+    renderWithRecoilRoot(
       <DeckEditor
         initialDeck={createNewDeck()}
         isNewDeck={true}
@@ -190,7 +192,7 @@ describe('DeckEditor', () => {
 
   it('should be reset when initialDeck is changed', () => {
     const firstDeck = testEnglishDeck(0);
-    const { rerender } = render(
+    const { rerender } = renderWithRecoilRoot(
       <DeckEditor
         initialDeck={firstDeck}
         isNewDeck={true}
@@ -202,14 +204,17 @@ describe('DeckEditor', () => {
 
     expect(screen.queryByDisplayValue(firstDeck.metaData.title)).toBeInTheDocument();
 
+    // unfortunately, RecoilRoot needs to be provided again on rerenders
     rerender(
-      <DeckEditor
-        initialDeck={createNewDeck()}
-        isNewDeck={true}
-        onCreateDeckClick={noop}
-        onDeleteDeckClick={noop}
-        onGoBackClick={noop}
-      />
+      <RecoilRoot>
+        <DeckEditor
+          initialDeck={createNewDeck()}
+          isNewDeck={true}
+          onCreateDeckClick={noop}
+          onDeleteDeckClick={noop}
+          onGoBackClick={noop}
+        />
+      </RecoilRoot>
     );
 
     expect(screen.queryByDisplayValue(firstDeck.metaData.title)).not.toBeInTheDocument();

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -3,3 +3,29 @@
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
 import '@testing-library/jest-dom';
+
+/*
+ * Custom matchers; update `jest.d.ts` to provide typings for these matchers.
+ *
+ * The first argument is always the received value from expectation chaining.
+ * You should not include the first argument in the declaration type (jest.d.ts)
+ */
+expect.extend({
+  async toMatchPredicate(
+    received: unknown,
+    predicate: (received: unknown) => Promise<boolean> | boolean
+  ) {
+    const matched = await predicate(received);
+    if (matched) {
+      return {
+        pass: true,
+        message: () => `Expected ${received} not to match the predicate`,
+      };
+    } else {
+      return {
+        pass: false,
+        message: () => `Expected ${received} to match the predicate`,
+      };
+    }
+  },
+});

--- a/src/state/init.ts
+++ b/src/state/init.ts
@@ -1,0 +1,16 @@
+import { MutableSnapshot } from 'recoil';
+import { AuthJwt, oauth2JwtState } from './oauth2-jwt';
+import { useLocalStorage } from '../hooks/use-local-storage';
+
+export const enum LocalStorageKeys {
+  'authJwt' = 'auth-jwt',
+}
+
+export function initRecoilState(snapshot: MutableSnapshot) {
+  const simpleLocalStorage = useLocalStorage();
+  // load jwt tokens from user storage
+  const authJwt = simpleLocalStorage.getObject<AuthJwt>(LocalStorageKeys.authJwt);
+  if (authJwt) {
+    snapshot.set(oauth2JwtState, authJwt);
+  }
+}

--- a/src/state/oauth2-jwt.ts
+++ b/src/state/oauth2-jwt.ts
@@ -1,0 +1,12 @@
+import { atom } from 'recoil';
+
+// TODO: backend does not send refreshToken so we're just going to make that value optional for now
+export interface AuthJwt {
+  accessToken: string;
+  refreshToken?: string;
+}
+
+export const oauth2JwtState = atom<AuthJwt | undefined>({
+  key: 'oauth2JwtState',
+  default: undefined,
+});


### PR DESCRIPTION
extends our fetch-wrapper to prep for handling auth JWTs + some misc stuff

### useFetchWrapper
- now able to retry requests (by default once)
- if a request fails on the server (e.g. 401 due to invalid JWT), we have a place to refresh the token (currently a TODO)

### useUserClient / useLocalStorage
- an attempt to log the user in will serialize the token to local storage
  - default `localStorage` only allows strings, `useLocalStorage` abstraction allows objects
- the serialized token lives in a recoil atom
  - if token in local storage when app first loads, it will be passed to the atom as a init step

### miscellaneous things added
- object schema validator (type-guards for objects)
- custom jasmine matcher `.toMatchPredicate(predicate)` to chain result of expectation to a predicate
- tests for the schema validator and fetch wrapper retries  