### PR TITLE
fix: add base href to avoid url-rewrite using resource url as base

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -6,6 +6,13 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
     <meta name="description" content="Web site created using create-react-app" />
+
+    <!--
+      URL rewriting any %PUBLIC_URL%/* to %PUBLIC_URL%/ will incorrectly 
+      retain the resource URL (*/) so we need to serve from /
+    -->
+    <base href="/">
+
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
     <!--
       manifest.json provides metadata used when your web app is installed on a


### PR DESCRIPTION
an example rewrite of `/decks/1` -> `/` should now serve the right static files