### PR TITLE
fix: resolve invalid hook call in resource fetchers

### DIFF
--- a/src/components/resource-loader/resource-loader.tsx
+++ b/src/components/resource-loader/resource-loader.tsx
@@ -6,19 +6,20 @@ import { createNewDeck } from '../../models/deck';
 import { LoadingPage } from '../loading-page/loading-page';
 
 interface ResourceLoaderProps<T> {
-  resourceFetcher: (resourceId: string | undefined) => Promise<T>;
+  routeParameter: string;
+  resourceFetcher: (resourceId: string | undefined) => () => Promise<T>;
   resourceConsumer: (resource: T) => JSX.Element;
-  useParamsIdName: string;
 }
 
 export const ResourceLoader = <T extends React.ReactNode>({
-  useParamsIdName,
-  resourceConsumer,
+  routeParameter,
   resourceFetcher,
+  resourceConsumer,
 }: ResourceLoaderProps<T>) => {
   const [resource, setResource] = useState<T | undefined>();
-  const { [useParamsIdName]: resourceId } = useParams();
+  const { [routeParameter]: resourceId } = useParams();
   const location = useLocation();
+  const resourceFetcherClosure = resourceFetcher(resourceId);
 
   useEffect(() => {
     fetchResourceAndRefresh();
@@ -26,29 +27,34 @@ export const ResourceLoader = <T extends React.ReactNode>({
 
   if (resource === undefined) {
     return <LoadingPage label="loading page..." />;
+  } else {
+    return resourceConsumer(resource);
   }
-
-  return resourceConsumer(resource);
 
   async function fetchResourceAndRefresh() {
     setResource(undefined);
-    const newResource = await resourceFetcher(resourceId);
+    const newResource = await resourceFetcherClosure();
     setResource(newResource);
   }
 };
 
-export async function loadDeck(deckId: string | undefined, allowUndefinedDeckId = false) {
+export function loadDeck(deckId: string | undefined, allowUndefinedDeckId = false) {
+  // hooks outside of functional components must be consumed immediately by the component
   const { getDeckById } = useDecksClient();
   const { getCardsByDeckId } = useCardsClient();
 
-  if (deckId === undefined) {
-    if (allowUndefinedDeckId) {
-      return createNewDeck();
+  // create a closure around the hooks
+  // we can invoke this whenever we actually want to load the resource
+  return async () => {
+    if (deckId === undefined) {
+      if (allowUndefinedDeckId) {
+        return createNewDeck();
+      }
+      throw Error('deckId cannot be undefined');
     }
-    throw Error('deckId cannot be undefined');
-  }
 
-  const [deck, cards] = await Promise.all([getDeckById(deckId), getCardsByDeckId(deckId)]);
-  deck.cards = cards;
-  return deck;
+    const [deck, cards] = await Promise.all([getDeckById(deckId), getCardsByDeckId(deckId)]);
+    deck.cards = cards;
+    return deck;
+  };
 }

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -38,7 +38,7 @@ function getStudyPage() {
   const studyPageClosure = (deck: Deck) => <StudyPage deck={deck} />;
   return (
     <ResourceLoader
-      useParamsIdName="deckId"
+      routeParameter="deckId"
       resourceFetcher={loadDeck}
       resourceConsumer={studyPageClosure}
     />
@@ -49,7 +49,7 @@ function getEditDeckPage(allowUndefinedDeckId: boolean) {
   const editDeckPageClosure = (deck: Deck) => <EditDeckPage deck={deck} />;
   return (
     <ResourceLoader
-      useParamsIdName="deckId"
+      routeParameter="deckId"
       resourceFetcher={(deckId: string | undefined) => loadDeck(deckId, allowUndefinedDeckId)}
       resourceConsumer={editDeckPageClosure}
     />
@@ -60,7 +60,7 @@ function getViewDeckPage() {
   const viewDeckPageClosure = (deck: Deck) => <ViewDeckPage deck={deck} />;
   return (
     <ResourceLoader
-      useParamsIdName="deckId"
+      routeParameter="deckId"
       resourceFetcher={loadDeck}
       resourceConsumer={viewDeckPageClosure}
     />


### PR DESCRIPTION
had a bit of a merge conflict between the JWT fetch wrapper and resource fetchers

the JWT PR added hooks to the fetch wrapper which caused a bug in the resource fetcher PR to surface.
specifically, the Rule of Hooks: [React doesn't allow hooks to be called outside of functional components / custom hooks](https://reactjs.org/docs/hooks-rules.html)

---

### Solution
- make the resource fetchers act like `custom hooks`! where logic can be lazily evaluated, but hooks consumed immediately
  - signature of resource fetchers are now `() => Promise<T>` 
- resource loader immediately invokes the resource fetcher for hooks, but the actual logic is wrapped in a closure to be invoked later