### PR TITLE
feat: lazily load audio files

### DIFF
--- a/src/components/flashcard/card-face/card-face.tsx
+++ b/src/components/flashcard/card-face/card-face.tsx
@@ -3,6 +3,7 @@ import TextareaAutoSize from 'react-textarea-autosize';
 import { CardMenu } from './card-menu/card-menu';
 import { SpeakerIcon } from '../../../assets/icons/speaker-icon/speaker-icon';
 import { CardContent, CardLanguage } from '../../../models/card-content';
+import { LazyAudio } from '../../../models/lazy-audio';
 import { Button } from '../../button/button';
 import './card-face.scss';
 
@@ -15,7 +16,7 @@ interface CardFaceProps {
   className?: string;
   onChange?: (cardContent: CardContent) => void;
   onFocus?: (event: React.FocusEvent<HTMLTextAreaElement>) => void;
-  onSpeakerClick?: (audioFile?: HTMLAudioElement) => void;
+  onSpeakerClick?: (audioFile?: LazyAudio) => void;
   onSwapContentClick?: () => void;
 }
 

--- a/src/components/flashcard/flashcard.tsx
+++ b/src/components/flashcard/flashcard.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useRef } from 'react';
 import { CardFace } from './card-face/card-face';
 import { Card } from '../../models/card';
 import { CardContent } from '../../models/card-content';
+import { LazyAudio } from '../../models/lazy-audio';
 import './flashcard.scss';
 
 interface FlashcardProps {
@@ -9,7 +10,7 @@ interface FlashcardProps {
   variant: 'active' | 'inactive' | 'readonly';
   onCardChange?: (card: Card) => void;
   onFocus?: (event: React.FocusEvent<HTMLTextAreaElement>) => void;
-  onSpeakerClick?: (audioFile?: HTMLAudioElement) => void;
+  onSpeakerClick?: (audioFile?: LazyAudio) => void;
 }
 
 export const Flashcard = ({

--- a/src/components/read-only-flashcard-set/read-only-flashcard-set.tsx
+++ b/src/components/read-only-flashcard-set/read-only-flashcard-set.tsx
@@ -1,5 +1,6 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { Card } from '../../models/card';
+import { LazyAudio } from '../../models/lazy-audio';
 import { Flashcard } from '../flashcard/flashcard';
 import './read-only-flashcard-set.scss';
 
@@ -9,18 +10,33 @@ interface ReadOnlyFlashcardSetProps {
 }
 
 export const ReadOnlyFlashcardSet = ({ className = '', cards }: ReadOnlyFlashcardSetProps) => {
+  const [playingAudioFile, setPlayingAudioFile] = useState<LazyAudio>();
+
+  // stops audio on destroy
+  useEffect(() => {
+    return () => {
+      playingAudioFile?.reset();
+    };
+  }, [playingAudioFile]);
+
   const flashcards = cards.map((card) => (
     <div key={card.key}>
       <Flashcard card={card} variant="readonly" onSpeakerClick={handleSpeakerClick} />
     </div>
   ));
   return <div className={`c-read-only-flashcard-set ${className}`}>{flashcards}</div>;
-};
 
-function handleSpeakerClick(audioFile?: HTMLAudioElement) {
-  if (audioFile === undefined) {
-    console.error('Audio file was undefined');
-    return;
+  function handleSpeakerClick(audioFile?: LazyAudio) {
+    if (audioFile === undefined) {
+      console.error('Audio file was undefined');
+      return;
+    }
+
+    // stop any current playing audio
+    playingAudioFile?.reset();
+
+    // play the new one
+    setPlayingAudioFile(audioFile);
+    audioFile?.play();
   }
-  audioFile.play();
-}
+};

--- a/src/hooks/api/use-cards-client.ts
+++ b/src/hooks/api/use-cards-client.ts
@@ -1,6 +1,7 @@
 import { useFetchWrapper } from './use-fetch-wrapper';
 import { ECHOSTUDY_API_URL, ECHOSTUDY_AUDIO_S3_URL } from '../../helpers/api';
 import { Card, createNewCard } from '../../models/card';
+import { LazyAudio } from '../../models/lazy-audio';
 
 /* eslint-disable @typescript-eslint/no-unused-vars */
 
@@ -147,12 +148,12 @@ function JsonToCard(obj: any) {
   card.front = {
     language: obj['flang'],
     text: obj['ftext'],
-    audio: new Audio(`${ECHOSTUDY_AUDIO_S3_URL}/${obj['faud']}`), // todo: defer new Audio bc some pages don't need it
+    audio: new LazyAudio(`${ECHOSTUDY_AUDIO_S3_URL}/${obj['faud']}`), // todo: defer new Audio bc some pages don't need it
   };
   card.back = {
     language: obj['blang'],
     text: obj['btext'],
-    audio: new Audio(`${ECHOSTUDY_AUDIO_S3_URL}/${obj['baud']}`), // todo: defer new Audio bc some pages don't need it
+    audio: new LazyAudio(`${ECHOSTUDY_AUDIO_S3_URL}/${obj['baud']}`), // todo: defer new Audio bc some pages don't need it
   };
   return card;
 }

--- a/src/models/card-content.ts
+++ b/src/models/card-content.ts
@@ -1,13 +1,14 @@
 import { AllDeckLanguages } from './deck';
+import { LazyAudio } from './lazy-audio';
 
 export const AllCardLanguages = ['Default', ...AllDeckLanguages] as const;
 
 export type CardLanguages = typeof AllCardLanguages;
-
 export type CardLanguage = CardLanguages[number];
+
 export interface CardContent {
   text: string;
-  audio?: HTMLAudioElement; // new Audio(...);
+  audio?: LazyAudio; // new LazyAudio(...);
   language: CardLanguage;
 }
 

--- a/src/models/lazy-audio.ts
+++ b/src/models/lazy-audio.ts
@@ -1,0 +1,114 @@
+/**
+ * Wrapper for the Audio object (HTMLAudioElement) that supports lazy loading/playing.
+ */
+export class LazyAudio {
+  private readonly audio: HTMLAudioElement = new Audio();
+
+  // whether or not the audio has enough data (readyState: 4 ==> HAVE_ENOUGH_DATA)
+  // we need to store this as a state because rewinding it resets this despite it being loaded
+  private hasEnoughData = false;
+
+  // whether or not the audio is already loading; prevents multiple network calls on double clicks.
+  private alreadyLoading = false;
+
+  constructor(private readonly audioUrl: string) {}
+
+  public async play(): Promise<void> {
+    return this.loadAudio({
+      onPlayable: () => {
+        this.audio.play();
+      },
+    });
+  }
+
+  public pause(): void {
+    this.audio.pause();
+  }
+
+  /**
+   * Fully resets the audio (and keeps it paused).
+   */
+  public reset(): void {
+    this.pause();
+    this.setCurrentTime(0);
+  }
+
+  public setCurrentTime(seconds: number): void {
+    this.audio.currentTime = seconds;
+  }
+
+  /**
+   * Warning: this method will load the audio if it hasn't already in order to get the correct duration.
+   */
+  public async getDuration(): Promise<number> {
+    return new Promise((resolve) => {
+      this.loadAudio({
+        onMetadataLoaded: () => resolve(this.audio.duration),
+      });
+    });
+  }
+
+  public addEventListener(
+    type: string,
+    listener: EventListenerOrEventListenerObject,
+    options?: boolean | AddEventListenerOptions
+  ): void {
+    this.audio.addEventListener(type, listener, options);
+  }
+
+  public removeEventListener(
+    type: string,
+    listener: EventListenerOrEventListenerObject,
+    options?: boolean | EventListenerOptions
+  ): void {
+    this.audio.removeEventListener(type, listener, options);
+  }
+
+  /**
+   * Load the audio and perform callbackOptions or short circuit and immediately invoke if it already has.
+   * @param callbackOptions actions to perform on certain thresholds of loading
+   */
+  private async loadAudio(callbackOptions?: {
+    onMetadataLoaded?: () => void;
+    onPlayable?: () => void;
+  }): Promise<void> {
+    if (this.alreadyLoading) {
+      return;
+    }
+
+    // enough data available to play through to the end
+    if (this.hasEnoughData) {
+      callbackOptions?.onMetadataLoaded?.();
+      callbackOptions?.onPlayable?.();
+      return;
+    }
+
+    return new Promise((resolve, reject) => {
+      // readyState: 1 (HAVE_METADATA)
+      this.audio.addEventListener(
+        'loadedmetadata',
+        () => {
+          callbackOptions?.onMetadataLoaded?.();
+        },
+        { once: true }
+      );
+      // readyState: 4 (HAVE_ENOUGH_DATA) -- highest ready state; we can resolve
+      this.audio.addEventListener(
+        'canplaythrough',
+        () => {
+          this.hasEnoughData = true;
+          this.alreadyLoading = false;
+          callbackOptions?.onPlayable?.();
+          resolve();
+        },
+        { once: true }
+      );
+      this.audio.addEventListener('error', reject, { once: true });
+
+      // actually load audio and wait for event listeners
+      this.alreadyLoading = true;
+      this.audio.src = this.audioUrl;
+      this.audio.load();
+    });
+  }
+}

--- a/src/models/mock/card-content.mock.ts
+++ b/src/models/mock/card-content.mock.ts
@@ -1,9 +1,10 @@
 import { CardContent, createNewCardContent } from '../card-content';
+import { LazyAudio } from '../lazy-audio';
 
 export const getTestFoxFront = (): CardContent => {
   const content = createNewCardContent();
   content.text = 'fox';
-  content.audio = new Audio(
+  content.audio = new LazyAudio(
     'https://weblio.hs.llnwd.net/e7/img/dict/kenej/audio/S-C3906E2_E-C392F5C.mp3'
   );
   return content;
@@ -12,14 +13,14 @@ export const getTestFoxFront = (): CardContent => {
 export const getTestFoxBack = (): CardContent => {
   const content = createNewCardContent();
   content.text = '狐';
-  content.audio = new Audio('https://0.tqn.com/z/g/japanese/library/media/audio/kitsune.wav');
+  content.audio = new LazyAudio('https://0.tqn.com/z/g/japanese/library/media/audio/kitsune.wav');
   return content;
 };
 
 export const getTestMonkeyFront = (): CardContent => {
   const content = createNewCardContent();
   content.text = 'monkey';
-  content.audio = new Audio(
+  content.audio = new LazyAudio(
     'https://weblio.hs.llnwd.net/e7/img/dict/kenej/audio/S-A92E9A0_E-A9307A8.mp3'
   );
   return content;
@@ -28,14 +29,14 @@ export const getTestMonkeyFront = (): CardContent => {
 export const getTestMonkeyBack = (): CardContent => {
   const content = createNewCardContent();
   content.text = '猿';
-  content.audio = new Audio('https://0.tqn.com/z/g/japanese/library/media/audio/saru.wav');
+  content.audio = new LazyAudio('https://0.tqn.com/z/g/japanese/library/media/audio/saru.wav');
   return content;
 };
 
 export const getTestMouseFront = (): CardContent => {
   const content = createNewCardContent();
   content.text = 'mouse';
-  content.audio = new Audio(
+  content.audio = new LazyAudio(
     'https://weblio.hs.llnwd.net/e7/img/dict/kenej/audio/S-CBE8B66_E-CBEB33E.mp3'
   );
   return content;
@@ -44,6 +45,6 @@ export const getTestMouseFront = (): CardContent => {
 export const getTestMouseBack = (): CardContent => {
   const content = createNewCardContent();
   content.text = 'ネズミ';
-  content.audio = new Audio('https://0.tqn.com/z/g/japanese/library/media/audio/nezumi.wav');
+  content.audio = new LazyAudio('https://0.tqn.com/z/g/japanese/library/media/audio/nezumi.wav');
   return content;
 };


### PR DESCRIPTION
# note to self: please rebase before merging to `main`
# note to derrick: i rebased off your branch so only review the last commit

### Loading all audio files when viewing/studying a deck is inefficient.
  - users will likely not listen to all audio files nor even listen to any audio files at all
instead, we lazily load audio files when needed using the new `LazyAudio` wrapper 

**(read header comment in `lazy-audio.ts`, mini architecture discussion)**

### Other improvements
- audio pauses and resumes correctly in a study session (need to reset active audio while waiting)
- in the deck viewer, starting another audio will stop any ongoing audio from playing

---

### (deck viewer): lazy loading on click, audio stops when playing a different one
https://user-images.githubusercontent.com/29434693/188330736-ca7af785-dcbe-4ce1-8779-223dd5170a5b.mp4

### (study page): fluid pause and resuming
https://user-images.githubusercontent.com/29434693/188330754-fb327439-11c3-43ae-b9d4-476371e8591f.mp4
