### PR TITLE
feat(css): improve landing page on smaller devices

### DIFF
--- a/src/assets/_styles.scss
+++ b/src/assets/_styles.scss
@@ -1,6 +1,7 @@
 @import './colors';
 
-// media query sizes
+// media query sizes (widths)
+$tiny-screen: 375px;
 $small-screen: 512px;
 $sm-md-screen: 640px;
 $medium-screen: 768px;

--- a/src/components/header/header.scss
+++ b/src/components/header/header.scss
@@ -11,6 +11,7 @@ $search-bar-offset: ($content-padding - $element-gap);
   box-sizing: border-box;
   background-color: $deck-cover-blue;
   border-bottom: 1px solid $deck-cover-blue;
+  overflow: hidden;
 
   &.fixed {
     position: fixed;
@@ -29,12 +30,15 @@ $search-bar-offset: ($content-padding - $element-gap);
 
     .c-header-title {
       @include flex-center;
-      flex: 0 0 $sidebar-width;
       height: 100%;
-      // padding-right: $search-bar-offset;
-
+      flex: 0 0 $sidebar-width;
       color: $white;
       font-size: 30px;
+
+      @media screen and (max-width: $small-screen) {
+        flex: 0;
+        padding-left: ($element-gap);
+      }
 
       a.c-header-anchor {
         color: unset;
@@ -76,6 +80,10 @@ $search-bar-offset: ($content-padding - $element-gap);
       align-items: center;
       flex: 0 0 min(20vw, 100px);
       padding-right: $element-gap * 2;
+
+      @media screen and (max-width: $small-screen) {
+        padding-right: $element-gap;
+      }
 
       button {
         padding: 12px;

--- a/src/components/registration-panel/registration-panel.scss
+++ b/src/components/registration-panel/registration-panel.scss
@@ -1,61 +1,72 @@
 @import '../../assets/styles';
 @import '../../assets/colors';
 
-.registration-component {
-  @include viewport-vertical-center;
-  margin-left: auto;
-  margin-right: auto;
-  border: 2px solid $light-blue;
-  width: fit-content;
-  color: white;
-  padding: 45px;
-  text-align: center;
-  border-radius: 45px;
+.registration-component-wrapper {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
 
-  @media screen and (max-width: $small-screen) {
-    width: 100%;
-    box-sizing: border-box;
-    padding: 20px;
-    margin: none;
-    border: none;
+  &::before,
+  &::after {
+    content: '';
+    flex: 1 0 24px;
   }
 
-  .registration-header {
-    font-size: 36px;
-  }
+  .registration-component {
+    margin-left: auto;
+    margin-right: auto;
+    border: 2px solid $light-blue;
+    width: fit-content;
+    color: white;
+    padding: 45px;
+    text-align: center;
+    border-radius: 45px;
 
-  .registration-sub-header {
-    font-size: 16px;
-    margin-bottom: 50px;
-  }
+    @media screen and (max-width: $small-screen) {
+      width: 100%;
+      box-sizing: border-box;
+      padding: 20px;
+      margin: none;
+      border: none;
+    }
 
-  .registration-form {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: 20px;
-    margin-bottom: 40px;
-    .registration-form-header {
-      font-size: 12px;
+    .registration-header {
+      font-size: 36px;
+    }
+
+    .registration-sub-header {
+      font-size: 16px;
+      margin-bottom: 50px;
+    }
+
+    .registration-form {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 20px;
+      margin-bottom: 40px;
+      .registration-form-header {
+        font-size: 12px;
+      }
+      .registration-button {
+        width: fit-content;
+        border-color: $white;
+        color: $white;
+      }
+    }
+
+    .registration-button-group {
+      margin-top: 40px;
+      .registration-button {
+        margin: 8px;
+      }
     }
     .registration-button {
-      width: fit-content;
+      display: inline-block;
       border-color: $white;
       color: $white;
+      background-color: transparent;
+      padding: 10px;
     }
-  }
-
-  .registration-button-group {
-    margin-top: 40px;
-    .registration-button {
-      margin: 8px;
-    }
-  }
-  .registration-button {
-    display: inline-block;
-    border-color: $white;
-    color: $white;
-    background-color: transparent;
-    padding: 10px;
   }
 }

--- a/src/components/registration-panel/registration-panel.tsx
+++ b/src/components/registration-panel/registration-panel.tsx
@@ -21,24 +21,30 @@ export const RegistrationPanel = ({
   onSwapPanelClick,
 }: RegistrationPanelProps) => {
   return (
-    <div className="registration-component">
-      <div className="registration-header">echoStudy</div>
-      <div className="registration-sub-header">learn anything. study anywhere.</div>
-      <div className="registration-form">
-        <div>{formHeader}</div>
-        {children}
-        <Button onClick={onSubmitClick} className="registration-button">
-          {submitLabel}
-        </Button>
-      </div>
-      <BubbleDivider variantColor="dark" variantType="divider" label="or" />
-      <div className="registration-button-group">
-        <Button onClick={onSwapPanelClick} variant="dark" className="registration-button">
-          {swapPanelLabel}
-        </Button>
-        <Button onClick={handleContinueAsGuestClick} variant="dark" className="registration-button">
-          continue as guest
-        </Button>
+    <div className="registration-component-wrapper">
+      <div className="registration-component">
+        <div className="registration-header">echoStudy</div>
+        <div className="registration-sub-header">learn anything. study anywhere.</div>
+        <div className="registration-form">
+          <div>{formHeader}</div>
+          {children}
+          <Button onClick={onSubmitClick} className="registration-button">
+            {submitLabel}
+          </Button>
+        </div>
+        <BubbleDivider variantColor="dark" variantType="divider" label="or" />
+        <div className="registration-button-group">
+          <Button onClick={onSwapPanelClick} variant="dark" className="registration-button">
+            {swapPanelLabel}
+          </Button>
+          <Button
+            onClick={handleContinueAsGuestClick}
+            variant="dark"
+            className="registration-button"
+          >
+            continue as guest
+          </Button>
+        </div>
       </div>
     </div>
   );

--- a/src/pages/landing-page/landing-page.scss
+++ b/src/pages/landing-page/landing-page.scss
@@ -10,7 +10,7 @@
     position: relative;
     display: flex;
     justify-content: center;
-    min-height: $medium-screen;
+    min-height: $sm-md-screen;
     height: 100vh;
     padding: 0px 24px;
     border-bottom: 4px solid $blue;
@@ -83,6 +83,10 @@
 
   .text-md-dynamic {
     font-size: 2.35vw;
+  }
+
+  .text-md-lg-dynamic {
+    font-size: min(3.45vw, 48px);
   }
 
   .text-lg-dynamic {

--- a/src/pages/landing-page/landing-page.scss
+++ b/src/pages/landing-page/landing-page.scss
@@ -86,7 +86,7 @@
   }
 
   .text-md-lg-dynamic {
-    font-size: min(3.45vw, 48px);
+    font-size: min(3.5vw, 48px);
   }
 
   .text-lg-dynamic {
@@ -121,7 +121,7 @@
     }
 
     .description {
-      padding: 64px 32px 32px 32px;
+      padding: 48px 32px 32px;
     }
 
     .action-button-container {
@@ -162,6 +162,10 @@
         border-radius: 16px;
         padding: 16px;
         user-select: none;
+
+        @media screen and (max-width: $medium-screen) {
+          width: min(75vw, $sm-md-screen);
+        }
       }
     }
   }

--- a/src/pages/landing-page/landing-page.tsx
+++ b/src/pages/landing-page/landing-page.tsx
@@ -38,7 +38,7 @@ export const LandingPage = () => {
                 </div>
               </div>
               <img className="wave-image" src={waveImage} loading="lazy" />
-              <div className="description text-md-dynamic">
+              <div className="description text-md-lg-dynamic">
                 the world&apos;s first hands-free audio flashcard app
               </div>
               <div className="action-button-container">

--- a/src/pages/not-found-page/not-found-page.scss
+++ b/src/pages/not-found-page/not-found-page.scss
@@ -15,11 +15,12 @@
 
   .message {
     font-size: 24px;
+    text-align: center;
   }
 
   .wave-image {
     width: 100%;
-    max-width: 436px;
+    max-width: min(90vw, $small-screen);
     height: auto;
     padding: 32px;
     user-select: none;


### PR DESCRIPTION
### note to self: change base to `main` and rebase after `add-authorized-routes` merges
---

- landing page has improved styling for smaller screens (respect to height)
- header no longer breaks out when width < 500px
- center 404 page text