### PR TITLE
feat: implement spaced repetition using the leitner system

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,11 @@
 {
-    "editor.codeActionsOnSave": {
-        "source.fixAll.eslint": true
-    },
-    "editor.tabSize": 2,
-    "editor.formatOnSave": true
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": true
+  },
+  "editor.tabSize": 2,
+  "editor.formatOnSave": true,
+  "jestrunner.jestCommand": "npm run test -- --watchAll=false",
+  "jestrunner.codeLens": [
+    "run"
+  ]
 }

--- a/src/helpers/func.ts
+++ b/src/helpers/func.ts
@@ -26,3 +26,25 @@ export function noop() {
 export function clamp(num: number, min: number, max: number) {
   return Math.min(Math.max(num, min), max);
 }
+
+/**
+ * Returns the absolute (floating) number of days between two dates.
+ */
+export function daysBetween(date1: Date, date2: Date): number {
+  const dayMs = 86400000;
+  const timeDiff = Math.abs(dateToUtcMs(date1) - dateToUtcMs(date2));
+  return Math.floor(timeDiff / dayMs);
+}
+
+/**
+ * Returns the date in UTC milliseconds.
+ */
+export function dateToUtcMs(date: Date): number {
+  return Date.UTC(
+    date.getFullYear(),
+    date.getMonth(),
+    date.getDate(),
+    date.getHours(),
+    date.getMinutes()
+  );
+}

--- a/src/hooks/api/use-cards-client.ts
+++ b/src/hooks/api/use-cards-client.ts
@@ -132,6 +132,7 @@ export function useCardsClient() {
 }
 
 function cardToJson(card: Card, deckId?: number) {
+  // TODO: backend needs to support way to update score
   return {
     frontText: card.front.text,
     backText: card.back.text,
@@ -142,10 +143,13 @@ function cardToJson(card: Card, deckId?: number) {
   };
 }
 
-function JsonToCard(obj: any) {
+function JsonToCard(obj: any): Card {
   const card = createNewCard();
   card.id = obj['id'];
   card.score = obj['score'];
+  card.dateCreated = new Date(obj['date_created']);
+  card.dateUpdated = new Date(obj['date_updated']);
+  card.dateTouched = new Date(obj['date_touched']);
   card.front = {
     language: obj['flang'],
     text: obj['ftext'],

--- a/src/hooks/tests/use-spaced-repetition.test.ts
+++ b/src/hooks/tests/use-spaced-repetition.test.ts
@@ -1,0 +1,108 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { Card } from '../../models/card';
+import { getTestFoxCard, getTestMonkeyCard, getTestMouseCard } from '../../models/mock/card.mock';
+import { testEnglishDeck } from '../../models/mock/deck.mock';
+import { BoxStaleDays, scoreToBox, useSpacedRepetition } from '../use-spaced-repetition';
+
+describe('useSpacedRepetition', () => {
+  const setup = () => {
+    const deck = testEnglishDeck(0);
+    const { result } = renderHook(() => useSpacedRepetition());
+    const spacedRepetition = result.current;
+    return { deck, spacedRepetition };
+  };
+
+  it('should yield study cards', () => {
+    const { deck, spacedRepetition } = setup();
+    const cards = [...Array(20)].map(() => getTestFoxCard());
+    deck.cards = cards;
+
+    expect(spacedRepetition.gatherStudyCards(deck, 20)).toHaveLength(20);
+  });
+
+  it('should yield study cards up to requested count', () => {
+    const { deck, spacedRepetition } = setup();
+    const cards = [...Array(25)].map(() => getTestFoxCard());
+    deck.cards = cards;
+
+    // requesting 20 from a 25 BOX1 (by default) cards
+    expect(spacedRepetition.gatherStudyCards(deck, 20)).toHaveLength(20);
+  });
+
+  it('should throw if not enough cards for requested count', () => {
+    const { deck, spacedRepetition } = setup();
+    const cards = [...Array(10)].map(() => getTestFoxCard());
+    deck.cards = cards;
+
+    // requesting 20, but only 10 in there
+    expect(() => spacedRepetition.gatherStudyCards(deck, 20)).toThrowError();
+  });
+
+  it('should always prioritize pooling stale cards', () => {
+    const { deck, spacedRepetition } = setup();
+    const staleFoxCards = [...Array(2)].map(() => getTestFoxCard());
+    const unstaleMouseCards = [...Array(25)].map(() => getTestMouseCard(1));
+    deck.cards = [...staleFoxCards, ...unstaleMouseCards];
+
+    const gather = (count: number) => spacedRepetition.gatherStudyCards(deck, count);
+    const areAllFoxCards = (cards: Card[]) => cards.every((card) => card.front.text === 'fox');
+
+    // there are only 2 stale cards; both of which are fox cards
+    expect(areAllFoxCards(gather(1))).toBe(true);
+    expect(areAllFoxCards(gather(2))).toBe(true);
+  });
+
+  it('should take from unstale cards if not enough stale cards for requested count', () => {
+    const { deck, spacedRepetition } = setup();
+    const staleFoxCards = [...Array(25)].map(() => getTestFoxCard());
+    const unstaleMouseCards = [...Array(25)].map(() => getTestMouseCard(4));
+    deck.cards = [...staleFoxCards, ...unstaleMouseCards];
+
+    const gather = (count: number) => spacedRepetition.gatherStudyCards(deck, count);
+    const hasMouseCards = (cards: Card[]) => cards.some((card) => card.front.text === 'mouse');
+
+    // N > 25 must contain some unstale (mouse) cards
+    expect(hasMouseCards(gather(26))).toBe(true);
+    expect(hasMouseCards(gather(50))).toBe(true);
+  });
+
+  it('should prioritize unstale cards based off days until stale', () => {
+    const { deck, spacedRepetition } = setup();
+    const staleFoxCards = [...Array(25)].map(() => getTestFoxCard());
+    const unstaleMouseCards = [...Array(25)].map(() => getTestMouseCard(4, staleInDaysDate(4, 2))); // ~2 day until stale
+    const unstaleMonkeyCard = [...Array(25)].map(() => getTestMonkeyCard(2, staleInDaysDate(2, 3))); // ~3 days until stale
+    deck.cards = [...staleFoxCards, ...unstaleMouseCards, ...unstaleMonkeyCard];
+
+    const gather = (count: number) => spacedRepetition.gatherStudyCards(deck, count);
+    const onlyCardTexts = (texts: string[], cards: Card[]) =>
+      cards.every((card) => texts.includes(card.front.text));
+
+    // N <= 25 all fox
+    expect(onlyCardTexts(['fox'], gather(1))).toBe(true);
+    expect(onlyCardTexts(['fox'], gather(13))).toBe(true);
+    expect(onlyCardTexts(['fox'], gather(25))).toBe(true);
+
+    // 25 < N <= 50, has fox, mouse
+    console.log(gather(26));
+    expect(onlyCardTexts(['fox', 'mouse'], gather(26))).toBe(true);
+    expect(onlyCardTexts(['fox', 'mouse'], gather(38))).toBe(true);
+    expect(onlyCardTexts(['fox', 'mouse'], gather(50))).toBe(true);
+
+    // N > 50, has fox, mouse, monkey
+    expect(onlyCardTexts(['fox', 'mouse', 'monkey'], gather(51))).toBe(true);
+    expect(onlyCardTexts(['fox', 'mouse', 'monkey'], gather(63))).toBe(true);
+    expect(onlyCardTexts(['fox', 'mouse', 'monkey'], gather(75))).toBe(true);
+  });
+});
+
+function staleInDaysDate(score: number, days: number): Date {
+  const box = scoreToBox(score);
+  const staleDays = BoxStaleDays[box];
+  return getDateNumDaysAgo(staleDays - days);
+}
+
+function getDateNumDaysAgo(numDays: number): Date {
+  const date = new Date();
+  date.setDate(date.getDate() - numDays);
+  return date;
+}

--- a/src/hooks/use-spaced-repetition.ts
+++ b/src/hooks/use-spaced-repetition.ts
@@ -1,0 +1,142 @@
+import { daysBetween } from '../helpers/func';
+import { compare, shuffle } from '../helpers/sort';
+import { Card } from '../models/card';
+import { Deck } from '../models/deck';
+
+/**
+ * Provides an interface that takes a deck and outputs a series of cards fit for study.
+ * Spaced repetition is implemented via the 5-box Leitner System.
+ *
+ * Scoring is proportional to the index of the boxes (score of 0 = Box 1, score of 4 = Box 5).
+ *   - If a card outcome is correct, it should be moved up a box.
+ *   - If a card outcome is incorrect, it is moved to Box 1 regardless of its current position.
+ *
+ * Cards that are 'pooled' to be chosen from follow these criteria:
+ *   - Cards in Box 1 are always candidate cards and are pooled
+ *   - If it has been more than stale days since the card was last studied, it is pooled
+ *   - Otherwise, it is not pooled unless specific settings controlling this has been set
+ *
+ * Defaults (via BoxStaleDays):
+ * [Box 1]  [Box 2]  [Box 3]  [Box 4]  [Box 5]
+ *   --       2d       5d       1wk      2wk
+ */
+export function useSpacedRepetition() {
+  // TODO: this is likely the file to expose methods to update card scores
+  // thus this hook is relatively small now, but we'll use the useCardClient in the future
+  return { gatherStudyCards };
+
+  /**
+   * Pool `count` (N) number of cards from the deck.
+   * If more cards are requested than there are, throw an exception.
+   *
+   * Otherwise, follow these heuristics:
+   *   Split cards into two divisions: stale and unstale cards.
+   *     - Add stale cards in a random order until we have N cards, then [[Return]]
+   *     - If we don't have enough cards, [[Continue]]
+   *   From the cards that *weren't* stale (unstale), order them by closest days until stale (smelly).
+   *     - Add smelly cards until we have enough -- which should be guaranteed, [[Return]].
+   */
+  function gatherStudyCards(deck: Deck, count: number): Card[] {
+    const pooledCards: Card[] = [];
+
+    const cards = deck.cards;
+    if (cards.length < count) {
+      throw new Error(
+        `Cannot pool ${count} cards when the deck only contains ${cards.length} cards`
+      );
+    }
+
+    // reduce into two boxes: cards that can be pooled (stale) and ones that cannot (unstale/fresh)
+    const { stale: staleCards, unstale: unstaleCards } = cards.reduce(
+      (result: Record<'stale' | 'unstale', Card[]>, card: Card) => {
+        const isStale = getDaysUntilStale(card) <= 0;
+        const key = isStale ? 'stale' : 'unstale';
+        result[key].push(card);
+        return result;
+      },
+      { stale: [], unstale: [] }
+    );
+
+    // add those cards from the pool until we have enough
+    for (const card of shuffle(staleCards)) {
+      pooledCards.push(card);
+
+      if (pooledCards.length == count) {
+        return pooledCards;
+      }
+    }
+
+    // if we don't have enough cards that were poolable (stale),
+    // we sort unstale cards by 'days until stale' (smelly) and pick amongst them
+    // also, we shuffle to introduce randomness since sort is a stable sort (TimSort)
+    const smellyCards = shuffle(unstaleCards).sort((card1, card2) => {
+      return compare(getDaysUntilStale(card1), getDaysUntilStale(card2));
+    });
+
+    // add the smelly cards until we have enough
+    for (const card of smellyCards) {
+      pooledCards.push(card);
+
+      if (pooledCards.length == count) {
+        return pooledCards;
+      }
+    }
+
+    // we should be guaranteed to never hit here
+    // but control flow is none the wiser
+    return pooledCards;
+  }
+}
+
+type Box = 'BOX1' | 'BOX2' | 'BOX3' | 'BOX4' | 'BOX5';
+
+// box number -> days before added to the pool
+export const BoxStaleDays: Record<Box, number> = {
+  BOX1: 0,
+  BOX2: 2,
+  BOX3: 5,
+  BOX4: 7,
+  BOX5: 14,
+};
+
+export function scoreToBox(score: number): Box {
+  // shouldn't really happen, but just as a fail-safe
+  if (score >= 5) {
+    return 'BOX5';
+  }
+
+  switch (score) {
+    case 0:
+      return 'BOX1';
+    case 1:
+      return 'BOX2';
+    case 2:
+      return 'BOX3';
+    case 3:
+      return 'BOX4';
+    case 4:
+      return 'BOX5';
+
+    default:
+      return 'BOX1';
+  }
+}
+
+export function getDaysUntilStale(card: Card) {
+  // BOX1 cards are always stale
+  if (card.score === 0) {
+    return 0;
+  }
+
+  // TODO TODO TODO TODO TODO TODO TODO TODO TODO TODO TODO TODO TODO TODO TODO
+  // TODO TODO TODO TODO TODO
+  const dateNow = new Date(); // TODO: time needs to match timezone with server.
+  // TODO TODO TODO TODO TODO
+  // TODO TODO TODO TODO TODO TODO TODO TODO TODO TODO TODO TODO TODO TODO TODO
+
+  const box = scoreToBox(card.score);
+  const daysUntilPoolable = BoxStaleDays[box];
+  const daysLastStudied = daysBetween(dateNow, card.dateUpdated);
+  const daysUntilStale = daysUntilPoolable - daysLastStudied;
+  return daysUntilStale;
+}

--- a/src/models/card.ts
+++ b/src/models/card.ts
@@ -7,8 +7,19 @@ export interface Card {
   front: CardContent;
   back: CardContent;
   score: number;
+  dateCreated: Date;
+  dateUpdated: Date;
+  dateTouched: Date;
 }
 
 export function createNewCard(): Card {
-  return { front: createNewCardContent(), back: createNewCardContent(), key: uuidv4(), score: 0 };
+  return {
+    front: createNewCardContent(),
+    back: createNewCardContent(),
+    key: uuidv4(),
+    score: 0,
+    dateCreated: new Date(),
+    dateUpdated: new Date(),
+    dateTouched: new Date(),
+  };
 }

--- a/src/models/mock/card.mock.ts
+++ b/src/models/mock/card.mock.ts
@@ -7,23 +7,29 @@ import {
 } from './card-content.mock';
 import { Card, createNewCard } from '../card';
 
-export const getTestFoxCard = (): Card => {
+export const getTestFoxCard = (score?: number, dateUpdated?: Date): Card => {
   const testCard = createNewCard();
   testCard.front = getTestFoxFront();
   testCard.back = getTestFoxBack();
+  testCard.score = score ?? 0;
+  testCard.dateUpdated = dateUpdated ?? testCard.dateUpdated;
   return testCard;
 };
 
-export const getTestMouseCard = (): Card => {
+export const getTestMouseCard = (score?: number, dateUpdated?: Date): Card => {
   const testCard = createNewCard();
   testCard.front = getTestMouseFront();
   testCard.back = getTestMouseBack();
+  testCard.score = score ?? 0;
+  testCard.dateUpdated = dateUpdated ?? testCard.dateUpdated;
   return testCard;
 };
 
-export const getTestMonkeyCard = (): Card => {
+export const getTestMonkeyCard = (score?: number, dateUpdated?: Date): Card => {
   const testCard = createNewCard();
   testCard.front = getTestMonkeyFront();
   testCard.back = getTestMouseBack();
+  testCard.score = score ?? 0;
+  testCard.dateUpdated = dateUpdated ?? testCard.dateUpdated;
   return testCard;
 };

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -10,8 +10,8 @@ import '@testing-library/jest-dom';
  */
 global.console = {
   ...console,
-  log: jest.fn(),
-  debug: jest.fn(),
+  // log: jest.fn(),
+  // debug: jest.fn(),
   info: jest.fn(),
   warn: jest.fn(),
   error: jest.fn(),


### PR DESCRIPTION
## Summary
- add workspace config for using `jest-runner` extension (codelens for tests)
- update card client (and interface) to deserialize dates from response
- implement spaced repetition using the leitner system

## Leitner System
- **Implementation:**
  - with a 5-box system (this can be configured relatively easily)
  - interface allows requesting `N` number of cards from a deck for studying
- **Boxes:**
  - the first box (BOX1) is a special box, it is always 'stale'
  - each box is a 'tier' of some sort, with a configured date of when a card is marked stale
    - (e.g.) cards in the last box (BOX5) are not stale until 2 weeks have occurred since the last study 
- **Scoring:**
  - all cards initially have a score of 0, hence in BOX1.
  - scoring a card correctly will increment the score, moving it up a box
  - scoring incorrectly will move the card back to BOX1 regardless of its correct position
- **Pooling (staleness):**
  - all cards that are stale are pooled (all BOX1 cards, any that are past due) to be selected from
  - if more cards are needed, remaining cards (unstale) are ranked by soonest to stale and chosen randomly