### PR TITLE
feat: responsive navbar and deck editor

### DIFF
--- a/src/assets/_styles.scss
+++ b/src/assets/_styles.scss
@@ -13,6 +13,9 @@ $sidebar-width: 260px;
 $header-height: 53px;
 $content-padding: 50px;
 
+$z-sidebar: 32;
+$z-header: 64;
+
 @mixin standard-transition {
   transition: 200ms;
 }

--- a/src/assets/_styles.scss
+++ b/src/assets/_styles.scss
@@ -15,6 +15,7 @@ $content-padding: 50px;
 
 $z-sidebar: 32;
 $z-header: 64;
+$z-popup-modal: 1024;
 
 @mixin standard-transition {
   transition: 200ms;

--- a/src/assets/icons/hamburger-menu-icon/hamburger-menu-icon.scss
+++ b/src/assets/icons/hamburger-menu-icon/hamburger-menu-icon.scss
@@ -1,0 +1,13 @@
+@import '../../colors';
+@import '../../styles';
+
+.hamburger-icon {
+  transition: 0.5s;
+  &.rotated {
+    transform: rotate(180deg);
+  }
+
+  &.dark path {
+    fill: $white;
+  }
+}

--- a/src/assets/icons/hamburger-menu-icon/hamburger-menu-icon.scss
+++ b/src/assets/icons/hamburger-menu-icon/hamburger-menu-icon.scss
@@ -2,11 +2,6 @@
 @import '../../styles';
 
 .hamburger-icon {
-  transition: 0.5s;
-  &.rotated {
-    transform: rotate(180deg);
-  }
-
   &.dark path {
     fill: $white;
   }

--- a/src/assets/icons/hamburger-menu-icon/hamburger-menu-icon.tsx
+++ b/src/assets/icons/hamburger-menu-icon/hamburger-menu-icon.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { noop } from '../../../helpers/func';
+import { ReactComponent as HamburgerMenuSvg } from '../../svg/hamburger-menu.svg';
+import './hamburger-menu-icon.scss';
+
+interface HamburgerMenuIconProps {
+  className?: string;
+  variant?: 'dark' | 'light';
+  orientation?: 'normal' | 'rotated';
+  onClick?: (event: React.MouseEvent) => void;
+}
+
+export const HamburgerMenuIcon = ({
+  className = '',
+  variant = 'light',
+  orientation = 'normal',
+  onClick = noop,
+}: HamburgerMenuIconProps) => {
+  return (
+    <HamburgerMenuSvg
+      className={`hamburger-icon ${variant} ${orientation} ${className}`}
+      onClick={onClick}
+    />
+  );
+};

--- a/src/assets/icons/hamburger-menu-icon/hamburger-menu-icon.tsx
+++ b/src/assets/icons/hamburger-menu-icon/hamburger-menu-icon.tsx
@@ -6,20 +6,15 @@ import './hamburger-menu-icon.scss';
 interface HamburgerMenuIconProps {
   className?: string;
   variant?: 'dark' | 'light';
-  orientation?: 'normal' | 'rotated';
   onClick?: (event: React.MouseEvent) => void;
 }
 
 export const HamburgerMenuIcon = ({
   className = '',
   variant = 'light',
-  orientation = 'normal',
-  onClick = noop,
+  onClick,
 }: HamburgerMenuIconProps) => {
   return (
-    <HamburgerMenuSvg
-      className={`hamburger-icon ${variant} ${orientation} ${className}`}
-      onClick={onClick}
-    />
+    <HamburgerMenuSvg className={`hamburger-icon ${variant} ${className}`} onClick={onClick} />
   );
 };

--- a/src/assets/svg/hamburger-menu.svg
+++ b/src/assets/svg/hamburger-menu.svg
@@ -1,0 +1,5 @@
+<svg width="40px" height="40px" viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg">
+	<path d="M41,14H7a2,2,0,0,1,0-4H41A2,2,0,0,1,41,14Z" fill="#efefef" />
+	<path d="M41,26H7a2,2,0,0,1,0-4H41A2,2,0,0,1,41,26Z" fill="#efefef" />
+	<path d="M41,38H7a2,2,0,0,1,0-4H41A2,2,0,0,1,41,38Z" fill="#efefef" />
+</svg>

--- a/src/components/deck-cover/deck-cover.scss
+++ b/src/components/deck-cover/deck-cover.scss
@@ -3,6 +3,7 @@
 
 .deck-cover {
   margin: 10px;
+
   .cover-front {
     @include flex-center;
     background-color: $deck-cover-blue;
@@ -15,6 +16,7 @@
     flex-direction: column;
     align-items: start;
     padding: 15px;
+
     label {
       font-size: 20px;
     }

--- a/src/components/drop-down/drop-down.scss
+++ b/src/components/drop-down/drop-down.scss
@@ -15,6 +15,14 @@
       color: $blue;
     }
   }
+
+  // custom classes (pass in with prop)
+  &.align-right {
+    display: flex;
+    align-items: baseline;
+    justify-content: end;
+    flex-wrap: wrap;
+  }
 }
 
 // avoid nesting in .drop-down to make menu more easily targetable

--- a/src/components/drop-down/drop-down.tsx
+++ b/src/components/drop-down/drop-down.tsx
@@ -31,9 +31,9 @@ export const DropDown = <T extends React.ReactNode>({
   useFocusTrap(dropDownMenuRef, isOpen);
 
   return (
-    <div className="drop-down">
+    <div className={`drop-down ${className}`}>
       <label className={accentVariant}>{label}</label>
-      <div className={`drop-down-menu ${className}`} ref={dropDownMenuRef}>
+      <div className="drop-down-menu" ref={dropDownMenuRef}>
         {getDropDownButton()}
         <DropDownOptions
           show={isOpen}

--- a/src/components/flip-tile/flip-tile.scss
+++ b/src/components/flip-tile/flip-tile.scss
@@ -27,6 +27,10 @@
     backface-visibility: hidden;
   }
 
+  .c-front {
+    text-align: center;
+  }
+
   .c-back {
     transform: rotateY(180deg);
   }
@@ -41,5 +45,4 @@
   background-color: $deck-cover-white;
   border-radius: 15px;
   box-sizing: border-box;
-  text-align: center;
 }

--- a/src/components/header/header.scss
+++ b/src/components/header/header.scss
@@ -11,7 +11,12 @@ $search-bar-offset: ($content-padding - $element-gap);
   box-sizing: border-box;
   background-color: $deck-cover-blue;
   border-bottom: 1px solid $deck-cover-blue;
-  overflow: hidden;
+
+  // all browsers but not supported below iOS/Safari 16.0 (09/11/2022)
+  @supports (overflow-x: clip) {
+    overflow-x: clip;
+    overflow-y: visible;
+  }
 
   &.fixed {
     position: fixed;

--- a/src/components/header/header.scss
+++ b/src/components/header/header.scss
@@ -5,7 +5,7 @@ $element-gap: 16px;
 $search-bar-offset: ($content-padding - $element-gap);
 
 .c-header {
-  z-index: 1;
+  z-index: $z-header;
   height: $header-height;
   width: 100%;
   box-sizing: border-box;
@@ -27,6 +27,24 @@ $search-bar-offset: ($content-padding - $element-gap);
     justify-content: space-between;
     height: 100%;
     gap: $element-gap;
+
+    .c-header-nav {
+      @include hover-pointer;
+      display: flex;
+      align-items: center;
+      padding-left: 16px;
+      width: 24px;
+      flex: 1;
+
+      .animated-icon {
+        display: flex;
+        align-items: center;
+      }
+
+      @media screen and (min-width: $medium-screen) {
+        display: none;
+      }
+    }
 
     .c-header-title {
       @include flex-center;

--- a/src/components/header/header.tsx
+++ b/src/components/header/header.tsx
@@ -1,9 +1,14 @@
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
-import { useRecoilValue } from 'recoil';
+import { AnimatePresence, motion, MotionConfig } from 'framer-motion';
+import { useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
+import { rootCertificates } from 'tls';
+import { CancelIcon } from '../../assets/icons/cancel-icon/cancel-icon';
+import { HamburgerMenuIcon } from '../../assets/icons/hamburger-menu-icon/hamburger-menu-icon';
 import { useUserClient } from '../../hooks/api/use-user-client';
 import { paths } from '../../routing/paths';
 import { authJwtState } from '../../state/auth-jwt';
+import { navToggledState } from '../../state/nav';
 import { userDecksSortedState } from '../../state/user-decks';
 import { Button } from '../button/button';
 import { DropDownOption } from '../drop-down-options/drop-down-options';
@@ -14,17 +19,31 @@ interface HeaderProps {
   className?: string;
   showSearchBar?: boolean;
   fixed?: boolean;
+  showHamburgerToggle?: boolean; // hamburger menu on smaller devices for sidebar
 }
 
-export const Header = ({ className = '', showSearchBar = true, fixed = true }: HeaderProps) => {
+export const Header = ({
+  className = '',
+  showSearchBar = true,
+  fixed = true,
+  showHamburgerToggle = false,
+}: HeaderProps) => {
   const authJwt = useRecoilValue(authJwtState);
   const decks = useRecoilValue(userDecksSortedState);
+  const [navToggled, setNavToggled] = useRecoilState(navToggledState);
+
   const userClient = useUserClient();
   const navigate = useNavigate();
 
   return (
     <div className={`c-header ${fixed ? 'fixed' : ''} ${className}`}>
       <div className="c-header-content">
+        {showHamburgerToggle && (
+          <div className="c-header-nav">
+            <AnimatePresence exitBeforeEnter>{getAnimatedNavToggleIcon()}</AnimatePresence>
+          </div>
+        )}
+
         <div className="c-header-title">
           <a className="c-header-anchor" href="/">
             <label>
@@ -49,6 +68,28 @@ export const Header = ({ className = '', showSearchBar = true, fixed = true }: H
       </div>
     </div>
   );
+
+  function getAnimatedNavToggleIcon() {
+    const toggleNavAction = () => setNavToggled((curr) => !curr);
+    const iconKey = navToggled ? 'cancel' : 'hamburger';
+
+    return (
+      <motion.div
+        className="animated-icon"
+        key={iconKey}
+        initial={{ opacity: 1 }}
+        animate={{ opacity: 1 }}
+        exit={{ opacity: 0, rotate: 180 }}
+        transition={{ duration: 0.25 }}
+      >
+        {navToggled ? (
+          <CancelIcon onClick={toggleNavAction} />
+        ) : (
+          <HamburgerMenuIcon onClick={toggleNavAction} />
+        )}
+      </motion.div>
+    );
+  }
 
   function getAccountButtons() {
     if (authJwt && authJwt.accessToken && authJwt.refreshToken) {

--- a/src/components/header/header.tsx
+++ b/src/components/header/header.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
-import { AnimatePresence, motion, MotionConfig } from 'framer-motion';
-import { useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
-import { rootCertificates } from 'tls';
+import { AnimatePresence, motion } from 'framer-motion';
+import { useRecoilState, useRecoilValue } from 'recoil';
 import { CancelIcon } from '../../assets/icons/cancel-icon/cancel-icon';
 import { HamburgerMenuIcon } from '../../assets/icons/hamburger-menu-icon/hamburger-menu-icon';
 import { useUserClient } from '../../hooks/api/use-user-client';

--- a/src/components/popup-modal/popup-modal.scss
+++ b/src/components/popup-modal/popup-modal.scss
@@ -5,10 +5,9 @@
 $bg-opacity: 0.33; // opacity to set background if modal is open
 $x-axis: 50%; // where to place popup on x-axis
 $y-axis: 25%; // where to place popup on y-axis
-$modal-z-index: 1000;
 
 .c-popup-modal-overlay {
-  z-index: $modal-z-index;
+  z-index: $z-popup-modal;
   position: fixed;
   inset: 0;
   min-width: 100%;
@@ -28,7 +27,7 @@ $modal-z-index: 1000;
 }
 
 .c-popup-modal-content {
-  z-index: $modal-z-index;
+  z-index: $z-popup-modal;
   position: absolute;
   left: $x-axis;
   top: $y-axis;

--- a/src/components/read-only-flashcard/read-only-flashcard.scss
+++ b/src/components/read-only-flashcard/read-only-flashcard.scss
@@ -17,7 +17,8 @@ $card-height: 175px;
     color: $light-blue;
     border-radius: 14px;
     height: $card-height;
-    overflow-y: scroll;
+    text-align: center;
+    overflow-y: auto;
 
     .rof-button-strip {
       position: sticky;

--- a/src/components/sidebar/sidebar.scss
+++ b/src/components/sidebar/sidebar.scss
@@ -2,7 +2,6 @@
 @import '../../assets/styles';
 
 .c-sidebar {
-  // z-index: 1;
   width: $sidebar-width;
   box-sizing: border-box;
   padding: $header-height 20px 0px 20px;
@@ -11,6 +10,12 @@
   background-color: $blue;
   color: $white;
   border-right: 1px solid $light-blue;
+
+  &.nav-toggled {
+    display: block;
+    z-index: $z-sidebar;
+    box-shadow: inset 0px ($header-height + 1) 0px 0px $light-blue;
+  }
 
   .c-sidebar-divider {
     height: 1px;

--- a/src/components/sidebar/sidebar.tsx
+++ b/src/components/sidebar/sidebar.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { NavLink } from 'react-router-dom';
+import { useRecoilValue } from 'recoil';
 import { SIDEBAR_ROUTE_ITEMS } from '../../routing/sidebar-routes';
+import { navToggledState } from '../../state/nav';
 import './sidebar.scss';
 
 interface SidebarProps {
@@ -8,8 +10,10 @@ interface SidebarProps {
 }
 
 export const Sidebar = ({ className = '' }: SidebarProps) => {
+  const navToggled = useRecoilValue(navToggledState);
+
   return (
-    <div className={`c-sidebar ${className}`}>
+    <div className={`c-sidebar ${navToggled ? 'nav-toggled' : ''} ${className}`}>
       <ul className="c-sidebar-items">
         {SIDEBAR_ROUTE_ITEMS.map((item) => (
           <NavLink

--- a/src/components/sidebar/sidebar.tsx
+++ b/src/components/sidebar/sidebar.tsx
@@ -3,9 +3,13 @@ import { NavLink } from 'react-router-dom';
 import { SIDEBAR_ROUTE_ITEMS } from '../../routing/sidebar-routes';
 import './sidebar.scss';
 
-export const Sidebar = () => {
+interface SidebarProps {
+  className?: string;
+}
+
+export const Sidebar = ({ className = '' }: SidebarProps) => {
   return (
-    <div className="c-sidebar">
+    <div className={`c-sidebar ${className}`}>
       <ul className="c-sidebar-items">
         {SIDEBAR_ROUTE_ITEMS.map((item) => (
           <NavLink

--- a/src/components/text-area/text-area.tsx
+++ b/src/components/text-area/text-area.tsx
@@ -3,6 +3,7 @@ import { ReactComponent as LockIcon } from '../../assets/svg/security-lock.svg';
 import './text-area.scss';
 
 export interface TextAreaProps {
+  className?: string;
   lines: number;
   value?: string;
   label?: React.ReactNode;
@@ -15,6 +16,7 @@ export interface TextAreaProps {
 }
 
 export const TextArea = ({
+  className = '',
   lines,
   value = '',
   label,
@@ -28,7 +30,7 @@ export const TextArea = ({
   const [isFocused, setFocused] = useState(false);
 
   return (
-    <div className={`c-text-area-wrapper ${variant}`}>
+    <div className={`c-text-area-wrapper ${variant} ${className}`}>
       {label && (
         <label className={`c-text-area-label ${shouldShowAsLegend() ? 'as-legend' : ''}`}>
           {label}

--- a/src/helpers/func.ts
+++ b/src/helpers/func.ts
@@ -13,6 +13,30 @@ export function debounce(func: Function, delayMs: number) {
   };
 }
 
+/**
+ * Eagerly throttles the invokation of a function to at most `ms`
+ * milliseconds since the last invokation.
+ */
+export function throttle(func: Function, delayMs: number) {
+  let timeoutId: ReturnType<typeof setTimeout>;
+  let lastInvoked: number;
+  return function (this: unknown, ...args: unknown[]) {
+    // eagerly invoke if never called yet
+    if (!lastInvoked) {
+      func.apply(this, args);
+      lastInvoked = Date.now();
+    } else {
+      clearTimeout(timeoutId);
+      timeoutId = setTimeout(() => {
+        if (Date.now() - lastInvoked >= delayMs) {
+          func.apply(this, args);
+          lastInvoked = Date.now();
+        }
+      }, delayMs - (Date.now() - lastInvoked));
+    }
+  };
+}
+
 export function noop() {
   return () => {};
 }

--- a/src/layouts/sidebar-layout/sidebar-layout.scss
+++ b/src/layouts/sidebar-layout/sidebar-layout.scss
@@ -68,5 +68,9 @@ $content-height: calc(100vh - #{$header-height + $content-padding});
       height: calc($content-height + 16px); // to offset flashcard-decks margin shrinking
       padding: 16px ($content-padding / 2);
     }
+
+    @media screen and (max-width: $small-screen) {
+      padding: 12px 8px;
+    }
   }
 }

--- a/src/layouts/sidebar-layout/sidebar-layout.scss
+++ b/src/layouts/sidebar-layout/sidebar-layout.scss
@@ -7,6 +7,29 @@ $height-without-header: calc(100vh - #{$header-height});
 // screen height without header or content padding
 $content-height: calc(100vh - #{$header-height + $content-padding});
 
+// only modify the <Header /> that has this class (which should only be this layout)
+.sidebar-layout-header {
+  .c-header-content {
+    .c-header-title {
+      @media screen and (max-width: $medium-screen) {
+        flex: 1;
+      }
+    }
+
+    .c-header-title {
+      @media screen and (max-width: $medium-screen) {
+        flex: 1;
+      }
+    }
+
+    .c-account-buttons {
+      @media screen and (max-width: $medium-screen) {
+        flex: 1;
+      }
+    }
+  }
+}
+
 .sidebar-layout-sidebar {
   @media screen and (max-width: $large-screen) {
     padding-left: unset;
@@ -41,7 +64,8 @@ $content-height: calc(100vh - #{$header-height + $content-padding});
     margin: auto;
 
     @media screen and (max-width: $medium-screen) {
-      padding: 8px ($content-padding / 2);
+      height: calc($content-height + 16px); // to offset flashcard-decks margin shrinking
+      padding: 16px ($content-padding / 2);
     }
   }
 }

--- a/src/layouts/sidebar-layout/sidebar-layout.scss
+++ b/src/layouts/sidebar-layout/sidebar-layout.scss
@@ -1,25 +1,47 @@
 @import '../../assets/colors';
 @import '../../assets/styles';
 
+// screen height without header
 $height-without-header: calc(100vh - #{$header-height});
-$header-and-padding: $header-height + $content-padding;
 
-// height without header and padding adjustments
-$content-height: calc(100vh - #{$header-and-padding});
+// screen height without header or content padding
+$content-height: calc(100vh - #{$header-height + $content-padding});
+
+.sidebar-layout-sidebar {
+  @media screen and (max-width: $large-screen) {
+    padding-left: unset;
+    width: $sidebar-width / 1.15;
+  }
+
+  @media screen and (max-width: $medium-screen) {
+    display: none;
+  }
+}
 
 .sidebar-layout-page-wrap {
   height: $height-without-header;
   margin-left: $sidebar-width;
   padding-top: $header-height;
 
+  @media screen and (max-width: $large-screen) {
+    margin-left: ($sidebar-width / 1.15);
+  }
+
+  @media screen and (max-width: $medium-screen) {
+    margin-left: 0;
+  }
+
   > .sidebar-layout-content {
     // create a stacking context so all internal z-indexes apply only between sibling elements
-    position: relative;
-    z-index: 0;
+    isolation: isolate;
 
     height: $content-height;
     padding: 20px $content-padding;
     max-width: 1700px;
     margin: auto;
+
+    @media screen and (max-width: $medium-screen) {
+      padding: 8px ($content-padding / 2);
+    }
   }
 }

--- a/src/layouts/sidebar-layout/sidebar-layout.scss
+++ b/src/layouts/sidebar-layout/sidebar-layout.scss
@@ -19,6 +19,7 @@ $content-height: calc(100vh - #{$header-height + $content-padding});
     .c-header-title {
       @media screen and (max-width: $medium-screen) {
         flex: 1;
+        padding: unset;
       }
     }
 

--- a/src/layouts/sidebar-layout/sidebar-layout.tsx
+++ b/src/layouts/sidebar-layout/sidebar-layout.tsx
@@ -1,10 +1,32 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { Outlet } from 'react-router-dom';
+import { useRecoilState } from 'recoil';
 import { Header } from '../../components/header/header';
 import { Sidebar } from '../../components/sidebar/sidebar';
+import { throttle } from '../../helpers/func';
+import { navToggledState } from '../../state/nav';
 import './sidebar-layout.scss';
 
 export const SidebarLayout = () => {
+  const [navToggled, setNavToggled] = useRecoilState(navToggledState);
+
+  // if nav open, listen for resizing to hide if resized to be bigger than breakpoint
+  useEffect(() => {
+    if (!navToggled) return;
+
+    const resizeHandler = throttle(() => {
+      // if greater than medium size (768px), hide nav
+      if (window.innerWidth > 768) {
+        setNavToggled(false);
+      }
+    }, 250);
+    window.addEventListener('resize', resizeHandler);
+
+    return () => {
+      window.removeEventListener('resize', resizeHandler);
+    };
+  }, [navToggled]);
+
   return (
     <>
       <Header className="sidebar-layout-header" showHamburgerToggle={true} />

--- a/src/layouts/sidebar-layout/sidebar-layout.tsx
+++ b/src/layouts/sidebar-layout/sidebar-layout.tsx
@@ -7,7 +7,7 @@ import './sidebar-layout.scss';
 export const SidebarLayout = () => {
   return (
     <>
-      <Header className="sidebar-layout-header" />
+      <Header className="sidebar-layout-header" showHamburgerToggle={true} />
       <Sidebar className="sidebar-layout-sidebar" />
       <div className="sidebar-layout-page-wrap">
         <div className="sidebar-layout-content">

--- a/src/layouts/sidebar-layout/sidebar-layout.tsx
+++ b/src/layouts/sidebar-layout/sidebar-layout.tsx
@@ -7,8 +7,8 @@ import './sidebar-layout.scss';
 export const SidebarLayout = () => {
   return (
     <>
-      <Header />
-      <Sidebar />
+      <Header className="sidebar-layout-header" />
+      <Sidebar className="sidebar-layout-sidebar" />
       <div className="sidebar-layout-page-wrap">
         <div className="sidebar-layout-content">
           <Outlet />

--- a/src/pages/decks/flashcard-decks.scss
+++ b/src/pages/decks/flashcard-decks.scss
@@ -7,9 +7,14 @@
   height: 100%;
   margin: 16px 0px;
 
+  @media screen and (max-width: $medium-screen) {
+    margin: 8px 0px;
+  }
+
   .decks-page-header {
     display: flex;
     justify-content: space-between;
+    gap: 16px;
 
     > label {
       color: $white;
@@ -63,7 +68,8 @@
 
     @media screen and (max-width: $medium-screen) {
       padding: unset;
-      margin-right: 20px;
+      padding-bottom: 8px;
+      margin-right: 24px;
     }
 
     > label {

--- a/src/pages/decks/flashcard-decks.scss
+++ b/src/pages/decks/flashcard-decks.scss
@@ -36,6 +36,12 @@
     width: 100%;
     height: 100%;
 
+    @media screen and (max-width: $medium-screen) {
+      margin: 20px 0px;
+      column-gap: unset;
+      row-gap: 24px;
+    }
+
     // ideally should have no more than 9-12 decks/pg to avoid overflow
     overflow-x: hidden;
     overflow-y: auto;
@@ -54,6 +60,11 @@
     padding: 16px 0px;
     margin-top: auto;
     text-align: center;
+
+    @media screen and (max-width: $medium-screen) {
+      padding: unset;
+      margin-right: 20px;
+    }
 
     > label {
       color: $light-blue;

--- a/src/pages/decks/flashcard-decks.tsx
+++ b/src/pages/decks/flashcard-decks.tsx
@@ -39,6 +39,7 @@ export const FlashcardDecksPage = () => {
       <div className="decks-page-header">
         <label>flashcard decks</label>
         <DropDown
+          className="align-right"
           variant="dark"
           options={AllSortRules.map((item) => ({ id: item, value: item, focusable: true }))}
           label="sort by"

--- a/src/pages/edit-deck-page/deck-editor/deck-editor.scss
+++ b/src/pages/edit-deck-page/deck-editor/deck-editor.scss
@@ -9,9 +9,16 @@
 
     .deck-editor-save-buttons {
       @include flex-center;
+      gap: 16px;
+
+      @media screen and (max-width: $tiny-screen) {
+        flex-direction: column;
+        align-items: end;
+        gap: 8px;
+      }
+
       .discard-changes-button {
         @include standard-transition;
-        margin-right: 15px;
         border: 1px solid transparent;
         color: $light-blue;
 

--- a/src/pages/edit-deck-page/deck-editor/meta-data-editor/meta-data-editor.scss
+++ b/src/pages/edit-deck-page/deck-editor/meta-data-editor/meta-data-editor.scss
@@ -23,15 +23,26 @@
   }
 
   .c-description-and-import-buttons {
-    margin-top: 16px;
     display: flex;
     align-items: flex-end;
+    flex-wrap: wrap;
+    margin-top: 16px;
     gap: 16px;
 
-    textarea {
-      padding: 12px 12px;
-      height: 58px;
-      border-radius: 10px;
+    .description-text-area {
+      flex: 4 1 600px;
+
+      textarea {
+        padding: 12px 12px;
+        height: 58px;
+        border-radius: 10px;
+      }
+    }
+
+    .popup-buttons {
+      @include flex-center;
+      flex: 1 1 200px;
+      gap: 16px;
     }
   }
 

--- a/src/pages/edit-deck-page/deck-editor/meta-data-editor/meta-data-editor.tsx
+++ b/src/pages/edit-deck-page/deck-editor/meta-data-editor/meta-data-editor.tsx
@@ -38,6 +38,7 @@ export const MetaDataEditor = ({
       </div>
       <div className="c-description-and-import-buttons">
         <TextArea
+          className="description-text-area"
           lines={2}
           label="description"
           variant="dark"
@@ -45,13 +46,15 @@ export const MetaDataEditor = ({
           value={deckMetaData.desc}
           onChange={handleDeckDescChange}
         />
-        <Button onClick={handleImportClick} size="medium">
-          import cards
-        </Button>
-        <ImportCardsPopup showPopup={showImportModal} onClose={handleImportCardsPopupClose} />
-        <Button onClick={handleExportClick} size="medium">
-          export deck
-        </Button>
+        <div className="popup-buttons">
+          <Button onClick={handleImportClick} size="medium">
+            import cards
+          </Button>
+          <ImportCardsPopup showPopup={showImportModal} onClose={handleImportCardsPopupClose} />
+          <Button onClick={handleExportClick} size="medium">
+            export deck
+          </Button>
+        </div>
       </div>
       <BubbleDivider
         variantType="drop-down"

--- a/src/state/nav.ts
+++ b/src/state/nav.ts
@@ -1,0 +1,7 @@
+import { atom } from 'recoil';
+
+// hamburger menu navigation toggled
+export const navToggledState = atom<boolean>({
+  key: 'navToggledState',
+  default: false,
+});


### PR DESCRIPTION
## note to self: change base to main and rebase before merging

ok, so this has been long coming but most are pages are usable on mobile/tablet/laptop devices
description is not fully in depth since there's a lot of minor tweaks too, but here are the biggest changes:

### navbar
- sidebar hides on smaller widths
- header responsive to display a navigation hamburger menu 
  - you can hit this to toggle the sidebar
  - it also automatically toggles itself off if resized to be larger again

### deck-editor
- heading now reorganizes on smaller devices (discard changes was too long)
- description and import (popup) buttons wrap on smaller screens

---


https://user-images.githubusercontent.com/29434693/191437097-d4a0d7c3-cd6a-46a8-abb1-32fe5ce8ea2f.mp4

