### PR TITLE
feat: ssl and https redirect

### DIFF
--- a/public/web.config
+++ b/public/web.config
@@ -1,8 +1,15 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <configuration>
 	<system.webServer>
 		<rewrite>
 			<rules>
+				<rule name="HTTPS Redirect" stopProcessing="true">
+					<match url=".*" />
+					<conditions logicalGrouping="MatchAll" trackAllCaptures="false">
+						<add input="{HTTPS}" pattern="^OFF$" />
+					</conditions>
+					<action type="Redirect" url="https://{HTTP_HOST}{REQUEST_URI}" />
+				</rule>
 				<rule name="React Routes" stopProcessing="true">
 					<match url=".*" />
 					<conditions logicalGrouping="MatchAll">

--- a/public/web.config
+++ b/public/web.config
@@ -9,6 +9,7 @@
 						<add input="{REQUEST_FILENAME}" matchType="IsFile" negate="true" />
 						<add input="{REQUEST_FILENAME}" matchType="IsDirectory" negate="true" />
 						<add input="{REQUEST_URI}" pattern="^/(api)" negate="true" />
+						<add input="{REQUEST_URI}" pattern="^/(.well-known)" negate="true" />
 					</conditions>
 					<action type="Rewrite" url="/" />
 				</rule>

--- a/public/web.config
+++ b/public/web.config
@@ -1,18 +1,18 @@
-<?xml version="1.0"?>  
-<configuration>  
-    <system.webServer>  
-        <rewrite>  
-            <rules>  
-                <rule name="React Routes" stopProcessing="true">  
-                    <match url=".*" />  
-                    <conditions logicalGrouping="MatchAll">  
-                        <add input="{REQUEST_FILENAME}" matchType="IsFile" negate="true" />  
-                        <add input="{REQUEST_FILENAME}" matchType="IsDirectory" negate="true" />  
-                        <add input="{REQUEST_URI}" pattern="^/(api)" negate="true" />  
-                    </conditions>  
-                    <action type="Rewrite" url="/" />  
-                </rule>  
-            </rules>  
-        </rewrite>  
-    </system.webServer>  
-</configuration>   
+<?xml version="1.0"?>
+<configuration>
+	<system.webServer>
+		<rewrite>
+			<rules>
+				<rule name="React Routes" stopProcessing="true">
+					<match url=".*" />
+					<conditions logicalGrouping="MatchAll">
+						<add input="{REQUEST_FILENAME}" matchType="IsFile" negate="true" />
+						<add input="{REQUEST_FILENAME}" matchType="IsDirectory" negate="true" />
+						<add input="{REQUEST_URI}" pattern="^/(api)" negate="true" />
+					</conditions>
+					<action type="Rewrite" url="/" />
+				</rule>
+			</rules>
+		</rewrite>
+	</system.webServer>
+</configuration>


### PR DESCRIPTION
server has certifytheweb installed but to verify the certificate it needs to allow access the static route `/.well-known/…` (i.e. don’t rewrite it to `/`)

also added a rule to redirect to HTTPS if not 