### PR TITLE
Added kebab menu to override outcome in Lesson Results Page

### DIFF
--- a/src/assets/icons/correct-icon/correct-icon.tsx
+++ b/src/assets/icons/correct-icon/correct-icon.tsx
@@ -7,5 +7,11 @@ interface CorrectIconProps {
 }
 
 export const CorrectIcon = ({ className = '' }: CorrectIconProps) => {
-  return <CorrectSvg className={`correct-icon ${className}`} />;
+  return (
+    <CorrectSvg
+      className={`correct-icon ${className}`}
+      aria-label="correct"
+      role="graphics-document"
+    />
+  );
 };

--- a/src/assets/icons/incorrect-icon/incorrect-icon.tsx
+++ b/src/assets/icons/incorrect-icon/incorrect-icon.tsx
@@ -7,5 +7,11 @@ interface IncorrectIconProps {
 }
 
 export const IncorrectIcon = ({ className = '' }: IncorrectIconProps) => {
-  return <IncorrectSvg className={`incorrect-icon ${className}`} />;
+  return (
+    <IncorrectSvg
+      className={`incorrect-icon ${className}`}
+      aria-label="incorrect"
+      role="graphics-document"
+    />
+  );
 };

--- a/src/assets/icons/kebab-menu-icon/kabab-menu-icon.scss
+++ b/src/assets/icons/kebab-menu-icon/kabab-menu-icon.scss
@@ -2,7 +2,19 @@
 @import '../../styles';
 
 .kebab-icon {
-  &.light path {
+  &.white path {
     fill: $white;
+  }
+
+  &.green path {
+    fill: $green;
+  }
+
+  &.red path {
+    fill: $red;
+  }
+
+  &.light-blue path {
+    fill: $light-blue;
   }
 }

--- a/src/assets/icons/kebab-menu-icon/kebab-menu-icon.tsx
+++ b/src/assets/icons/kebab-menu-icon/kebab-menu-icon.tsx
@@ -4,9 +4,9 @@ import './kabab-menu-icon.scss';
 
 interface KebabMenuIconProps {
   className?: string;
-  variant?: 'dark' | 'light';
+  variant?: 'blue' | 'white' | 'green' | 'red' | 'light-blue';
 }
 
-export const KebabMenuIcon = ({ className = '', variant = 'dark' }: KebabMenuIconProps) => {
+export const KebabMenuIcon = ({ className = '', variant = 'blue' }: KebabMenuIconProps) => {
   return <KebabMenuSvg className={`kebab-icon ${variant} ${className}`} />;
 };

--- a/src/assets/icons/skipped-icon/skipped-icon.tsx
+++ b/src/assets/icons/skipped-icon/skipped-icon.tsx
@@ -7,5 +7,11 @@ interface SkippedIconProps {
 }
 
 export const SkippedIcon = ({ className = '' }: SkippedIconProps) => {
-  return <SkippedSvg className={`skipped-icon ${className}`} />;
+  return (
+    <SkippedSvg
+      className={`skipped-icon ${className}`}
+      aria-label="skipped"
+      role="graphics-document"
+    />
+  );
 };

--- a/src/components/drop-down-options/drop-down-options.test.tsx
+++ b/src/components/drop-down-options/drop-down-options.test.tsx
@@ -58,7 +58,7 @@ describe('DropDownOptions', () => {
         ellipsisOverflow={false}
         show={true}
         options={TEST_OPTIONS_SMALL}
-        onOptionSelect={(option: DropDownOption<string>) => mockOnOptionSelect(option.value)}
+        onOptionSelect={(option) => mockOnOptionSelect(option.value)}
       />
     );
 
@@ -77,7 +77,7 @@ describe('DropDownOptions', () => {
         ellipsisOverflow={false}
         show={true}
         options={testOptions}
-        onOptionSelect={(option: DropDownOption<string>) => mockOnOptionSelect(option.value)}
+        onOptionSelect={(option) => mockOnOptionSelect(option.value)}
       />
     );
 

--- a/src/components/drop-down-options/drop-down-options.tsx
+++ b/src/components/drop-down-options/drop-down-options.tsx
@@ -8,8 +8,8 @@ import './drop-down-options.scss';
  *
  */
 export interface DropDownOption<T> {
-  id: string;
-  value: T;
+  id: T;
+  value: React.ReactNode;
   focusable: boolean;
 }
 
@@ -28,7 +28,7 @@ interface DropDownOptionsProps<T> {
  *  When enabled, a nested DropDownOptions component will not work due to
  *  this restriction: https://stackoverflow.com/a/6433475/14356299
  */
-export const DropDownOptions = <T extends React.ReactNode>({
+export const DropDownOptions = <T extends React.Key>({
   className = '',
   ellipsisOverflow = true,
   show,

--- a/src/components/drop-down-options/drop-down-options.tsx
+++ b/src/components/drop-down-options/drop-down-options.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ReactNode } from 'react';
 import { AnimatePresence } from 'framer-motion';
 import { Fade } from '../../animations/fade';
 import { Button } from '../button/button';
@@ -7,18 +7,18 @@ import './drop-down-options.scss';
 /**
  *
  */
-export interface DropDownOption<T> {
-  id: T;
-  value: React.ReactNode;
+export interface DropDownOption<I, V> {
+  id: I;
+  value: V;
   focusable: boolean;
 }
 
-interface DropDownOptionsProps<T> {
+interface DropDownOptionsProps<I, V> {
   className?: string;
   ellipsisOverflow: boolean;
   show: boolean;
-  options?: DropDownOption<T>[];
-  onOptionSelect: (option: DropDownOption<T>) => void;
+  options?: DropDownOption<I, V>[];
+  onOptionSelect: (option: DropDownOption<I, V>) => void;
 }
 
 /**
@@ -28,13 +28,13 @@ interface DropDownOptionsProps<T> {
  *  When enabled, a nested DropDownOptions component will not work due to
  *  this restriction: https://stackoverflow.com/a/6433475/14356299
  */
-export const DropDownOptions = <T extends React.Key>({
+export const DropDownOptions = <I extends string, V extends ReactNode>({
   className = '',
   ellipsisOverflow = true,
   show,
   options,
   onOptionSelect,
-}: DropDownOptionsProps<T>) => {
+}: DropDownOptionsProps<I, V>) => {
   return (
     <AnimatePresence>
       {show && options !== undefined && (
@@ -45,7 +45,7 @@ export const DropDownOptions = <T extends React.Key>({
     </AnimatePresence>
   );
 
-  function getOption(option: DropDownOption<T>) {
+  function getOption(option: DropDownOption<I, V>) {
     const dropDownOverflow = ellipsisOverflow ? 'ellipsis-overflow' : '';
     const className = `c-drop-down-option ${dropDownOverflow}`;
     if (option.focusable) {

--- a/src/components/drop-down-options/options.mock.ts
+++ b/src/components/drop-down-options/options.mock.ts
@@ -1,25 +1,25 @@
 import { DropDownOption } from './drop-down-options';
 
 // 0-indexed, (size = 1) generates [{id: 'test0', value: 'test0'}]
-export const createTestOptions = (size: number): DropDownOption<string>[] =>
+export const createTestOptions = (size: number): DropDownOption<string, string>[] =>
   [...Array(size)].map((_, index) => ({
     id: `test${index}`,
     value: `test${index}`,
     focusable: true,
   }));
 
-export const TEST_OPTIONS_SINGLE: DropDownOption<string>[] = createTestOptions(1);
+export const TEST_OPTIONS_SINGLE: DropDownOption<string, string>[] = createTestOptions(1);
 export const TEST_OPTIONS_SINGLE_VALUES: string[] = TEST_OPTIONS_SINGLE.map(getId);
 
-export const TEST_OPTIONS_SMALL: DropDownOption<string>[] = createTestOptions(10);
+export const TEST_OPTIONS_SMALL: DropDownOption<string, string>[] = createTestOptions(10);
 export const TEST_OPTIONS_SMALL_VALUES: string[] = TEST_OPTIONS_SMALL.map(getId);
 
-export const TEST_OPTIONS_MEDIUM: DropDownOption<string>[] = createTestOptions(100);
+export const TEST_OPTIONS_MEDIUM: DropDownOption<string, string>[] = createTestOptions(100);
 export const TEST_OPTIONS_MEDIUM_VALUES: string[] = TEST_OPTIONS_MEDIUM.map(getId);
 
-export const TEST_OPTIONS_LARGE: DropDownOption<string>[] = createTestOptions(1000);
+export const TEST_OPTIONS_LARGE: DropDownOption<string, string>[] = createTestOptions(1000);
 export const TEST_OPTIONS_LARGE_VALUES: string[] = TEST_OPTIONS_LARGE.map(getId);
 
-function getId(option: DropDownOption<string>) {
+function getId(option: DropDownOption<string, string>) {
   return option.id;
 }

--- a/src/components/drop-down-options/options.mock.ts
+++ b/src/components/drop-down-options/options.mock.ts
@@ -9,17 +9,17 @@ export const createTestOptions = (size: number): DropDownOption<string>[] =>
   }));
 
 export const TEST_OPTIONS_SINGLE: DropDownOption<string>[] = createTestOptions(1);
-export const TEST_OPTIONS_SINGLE_VALUES: string[] = TEST_OPTIONS_SINGLE.map(getValue);
+export const TEST_OPTIONS_SINGLE_VALUES: string[] = TEST_OPTIONS_SINGLE.map(getId);
 
 export const TEST_OPTIONS_SMALL: DropDownOption<string>[] = createTestOptions(10);
-export const TEST_OPTIONS_SMALL_VALUES: string[] = TEST_OPTIONS_SMALL.map(getValue);
+export const TEST_OPTIONS_SMALL_VALUES: string[] = TEST_OPTIONS_SMALL.map(getId);
 
 export const TEST_OPTIONS_MEDIUM: DropDownOption<string>[] = createTestOptions(100);
-export const TEST_OPTIONS_MEDIUM_VALUES: string[] = TEST_OPTIONS_MEDIUM.map(getValue);
+export const TEST_OPTIONS_MEDIUM_VALUES: string[] = TEST_OPTIONS_MEDIUM.map(getId);
 
 export const TEST_OPTIONS_LARGE: DropDownOption<string>[] = createTestOptions(1000);
-export const TEST_OPTIONS_LARGE_VALUES: string[] = TEST_OPTIONS_LARGE.map(getValue);
+export const TEST_OPTIONS_LARGE_VALUES: string[] = TEST_OPTIONS_LARGE.map(getId);
 
-function getValue(option: DropDownOption<string>) {
-  return option.value;
+function getId(option: DropDownOption<string>) {
+  return option.id;
 }

--- a/src/components/drop-down/drop-down.tsx
+++ b/src/components/drop-down/drop-down.tsx
@@ -15,7 +15,7 @@ interface DropDownProps<T> {
   onOptionSelect: (option: DropDownOption<T>) => void;
 }
 
-export const DropDown = <T extends React.ReactNode>({
+export const DropDown = <T extends React.Key>({
   variant = 'dark',
   label = '',
   className = '',

--- a/src/components/drop-down/drop-down.tsx
+++ b/src/components/drop-down/drop-down.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from 'react';
+import React, { ReactNode, useRef, useState } from 'react';
 import { ArrowIcon } from '../../assets/icons/arrow-icon/arrow-icon';
 import { useFocusTrap } from '../../hooks/use-focus-trap';
 import { useOutsideClick } from '../../hooks/use-outside-click';
@@ -6,23 +6,23 @@ import { Button } from '../button/button';
 import { DropDownOption, DropDownOptions } from '../drop-down-options/drop-down-options';
 import './drop-down.scss';
 
-interface DropDownProps<T> {
+interface DropDownProps<I, V> {
   variant?: 'dark' | 'light';
   label?: React.ReactNode;
   className?: string;
-  options: DropDownOption<T>[];
+  options: DropDownOption<I, V>[];
   buttonLabel: React.ReactNode;
-  onOptionSelect: (option: DropDownOption<T>) => void;
+  onOptionSelect: (option: DropDownOption<I, V>) => void;
 }
 
-export const DropDown = <T extends React.Key>({
+export const DropDown = <I extends string, V extends ReactNode>({
   variant = 'dark',
   label = '',
   className = '',
   options,
   buttonLabel,
   onOptionSelect,
-}: DropDownProps<T>) => {
+}: DropDownProps<I, V>) => {
   const [isOpen, setIsOpen] = useState(false);
   const accentVariant = variant === 'dark' ? 'light' : 'dark';
 
@@ -54,7 +54,7 @@ export const DropDown = <T extends React.Key>({
     );
   }
 
-  function handleOptionSelect(option: DropDownOption<T>) {
+  function handleOptionSelect(option: DropDownOption<I, V>) {
     onOptionSelect(option);
     setIsOpen(false);
   }

--- a/src/components/flashcard/card-face/card-menu/card-menu.tsx
+++ b/src/components/flashcard/card-face/card-menu/card-menu.tsx
@@ -25,7 +25,7 @@ export const CardMenu = ({
   const langDropdownId = 'lang';
   const swapOptionId = 'swap';
 
-  const options: DropDownOption<React.ReactNode>[] = [
+  const options: DropDownOption<React.Key>[] = [
     { id: langDropdownId, focusable: false, value: getLanguageDropdownOption() },
     { id: swapOptionId, focusable: true, value: getSwapOption() },
   ];
@@ -35,6 +35,7 @@ export const CardMenu = ({
       className="c-card-menu"
       options={options}
       isOpen={isOpen}
+      variant="blue"
       setIsOpen={setIsOpen}
       onOptionSelect={handleOptionSelect}
     />

--- a/src/components/flashcard/card-face/card-menu/card-menu.tsx
+++ b/src/components/flashcard/card-face/card-menu/card-menu.tsx
@@ -1,10 +1,16 @@
-import React, { useState } from 'react';
+import React, { ReactNode, useState } from 'react';
 import { SwapIcon } from '../../../../assets/icons/swap-icon/swap-icon';
 import { AllCardLanguages, CardLanguage } from '../../../../models/language';
 import { DropDownOption } from '../../../drop-down-options/drop-down-options';
 import { KebabMenu } from '../../../kebab-menu/kebab-menu';
 import { LanguageDropDown } from '../../../language-drop-down/drop-down-options/language-drop-down';
 import './card-menu.scss';
+
+const langDropdownId = 'lang';
+const swapOptionId = 'swap';
+
+const dropDownOptionIDs = [langDropdownId, swapOptionId] as const;
+type CardMenuDropdownID = typeof dropDownOptionIDs[number];
 
 interface CardFaceProps {
   language: CardLanguage;
@@ -22,10 +28,8 @@ export const CardMenu = ({
   onSwapContentClick,
 }: CardFaceProps) => {
   const [isOpen, setIsOpen] = useState(false);
-  const langDropdownId = 'lang';
-  const swapOptionId = 'swap';
 
-  const options: DropDownOption<React.Key>[] = [
+  const options: DropDownOption<CardMenuDropdownID, ReactNode>[] = [
     { id: langDropdownId, focusable: false, value: getLanguageDropdownOption() },
     { id: swapOptionId, focusable: true, value: getSwapOption() },
   ];
@@ -41,7 +45,7 @@ export const CardMenu = ({
     />
   );
 
-  function handleOptionSelect(option: DropDownOption<React.ReactNode>) {
+  function handleOptionSelect(option: DropDownOption<CardMenuDropdownID, ReactNode>) {
     if (option.id === swapOptionId) {
       onSwapContentClick();
       setIsOpen(false);

--- a/src/components/header/header.scss
+++ b/src/components/header/header.scss
@@ -46,7 +46,7 @@ $search-bar-offset: ($content-padding - $element-gap);
         align-items: center;
       }
 
-      @media screen and (min-width: $medium-screen) {
+      @media screen and (min-width: $large-screen) {
         display: none;
       }
     }
@@ -88,7 +88,7 @@ $search-bar-offset: ($content-padding - $element-gap);
       align-items: center;
       flex: 8 1 auto;
 
-      @media screen and (max-width: $medium-screen) {
+      @media screen and (max-width: $large-screen) {
         display: none;
       }
 

--- a/src/components/header/header.tsx
+++ b/src/components/header/header.tsx
@@ -111,7 +111,7 @@ export const Header = ({
     }
   }
 
-  function getDeckOptions(): DropDownOption<string>[] {
+  function getDeckOptions(): DropDownOption<string, string>[] {
     return decks.map((deck) => ({
       id: deck.metaData.id.toString(),
       value: deck.metaData.title,

--- a/src/components/kebab-menu/kebab-menu.tsx
+++ b/src/components/kebab-menu/kebab-menu.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from 'react';
+import React, { ReactNode, useRef, useState } from 'react';
 import { KebabMenuIcon } from '../../assets/icons/kebab-menu-icon/kebab-menu-icon';
 import { noop } from '../../helpers/func';
 import { useFocusTrap } from '../../hooks/use-focus-trap';
@@ -7,23 +7,23 @@ import { Button } from '../button/button';
 import { DropDownOption, DropDownOptions } from '../drop-down-options/drop-down-options';
 import './kebab-menu.scss';
 
-interface KebabMenuProps<T> {
+interface KebabMenuProps<I, V> {
   className?: string;
   variant: 'blue' | 'white' | 'green' | 'red' | 'light-blue';
-  options?: DropDownOption<T>[];
+  options?: DropDownOption<I, V>[];
   isOpen: boolean;
   setIsOpen: (isOpen: boolean) => void;
-  onOptionSelect?: (option: DropDownOption<T>) => void;
+  onOptionSelect?: (option: DropDownOption<I, V>) => void;
 }
 
-export const KebabMenu = <T extends React.Key>({
+export const KebabMenu = <I extends string, V extends ReactNode>({
   className = '',
   variant,
   options,
   isOpen,
   setIsOpen,
   onOptionSelect,
-}: KebabMenuProps<T>) => {
+}: KebabMenuProps<I, V>) => {
   const kebabMenuRef = useRef(null);
   useOutsideClick(kebabMenuRef, () => setIsOpen(false));
   useFocusTrap(kebabMenuRef, isOpen);

--- a/src/components/kebab-menu/kebab-menu.tsx
+++ b/src/components/kebab-menu/kebab-menu.tsx
@@ -9,14 +9,16 @@ import './kebab-menu.scss';
 
 interface KebabMenuProps<T> {
   className?: string;
+  variant: 'blue' | 'white' | 'green' | 'red' | 'light-blue';
   options?: DropDownOption<T>[];
   isOpen: boolean;
   setIsOpen: (isOpen: boolean) => void;
   onOptionSelect?: (option: DropDownOption<T>) => void;
 }
 
-export const KebabMenu = <T extends React.ReactNode>({
+export const KebabMenu = <T extends React.Key>({
   className = '',
+  variant,
   options,
   isOpen,
   setIsOpen,
@@ -27,7 +29,7 @@ export const KebabMenu = <T extends React.ReactNode>({
   useFocusTrap(kebabMenuRef, isOpen);
 
   return (
-    <div className={`c-kebab-menu ${className}`} ref={kebabMenuRef}>
+    <div className={`c-kebab-menu $${className}`} ref={kebabMenuRef}>
       <Button
         onClick={() => setIsOpen(!isOpen)}
         variant="invisible"
@@ -35,7 +37,7 @@ export const KebabMenu = <T extends React.ReactNode>({
         bubbleOnClickEvent={false}
         ariaLabel="kebab-menu"
       >
-        <KebabMenuIcon />
+        <KebabMenuIcon variant={variant} />
       </Button>
       <DropDownOptions
         className="c-kebab-menu-options"

--- a/src/components/language-drop-down/drop-down-options/language-drop-down.tsx
+++ b/src/components/language-drop-down/drop-down-options/language-drop-down.tsx
@@ -42,7 +42,7 @@ export const LanguageDropDown = <T extends DeckLanguages | CardLanguages>({
   );
 
   function handleOptionSelect(option: DropDownOption<T[number]>) {
-    const newLanguage = option.value;
+    const newLanguage = option.id;
     onLanguageSelect(newLanguage);
   }
 };

--- a/src/components/language-drop-down/drop-down-options/language-drop-down.tsx
+++ b/src/components/language-drop-down/drop-down-options/language-drop-down.tsx
@@ -41,7 +41,7 @@ export const LanguageDropDown = <T extends DeckLanguages | CardLanguages>({
     </div>
   );
 
-  function handleOptionSelect(option: DropDownOption<T[number]>) {
+  function handleOptionSelect(option: DropDownOption<T[number], T[number]>) {
     const newLanguage = option.id;
     onLanguageSelect(newLanguage);
   }

--- a/src/components/read-only-flashcard/read-only-flashcard.scss
+++ b/src/components/read-only-flashcard/read-only-flashcard.scss
@@ -9,6 +9,12 @@ $card-height: 175px;
   width: 100%;
   gap: 20px;
   margin: 10px 0px;
+
+  @media screen and (max-width: $medium-screen) {
+    display: block;
+    margin: 25px 0px;
+  }
+
   .rof-card-face {
     display: flex;
     flex-grow: 1;
@@ -19,6 +25,12 @@ $card-height: 175px;
     height: $card-height;
     text-align: center;
     overflow-y: auto;
+
+    @media screen and (max-width: $medium-screen) {
+      &:first-child {
+        margin-bottom: 10px;
+      }
+    }
 
     .rof-button-strip {
       position: sticky;

--- a/src/components/search-bar/search-bar.tsx
+++ b/src/components/search-bar/search-bar.tsx
@@ -102,11 +102,11 @@ export const SearchBar = ({
   }
 
   function optionIncludesValueFilter(option: DropDownOption<string>) {
-    const optionVal = option.value;
+    const optionId = option.id;
     const searchVal = value.trim();
     return dropDownIgnoreCase
-      ? includesIgnoreCase(optionVal, searchVal)
-      : optionVal.includes(searchVal);
+      ? includesIgnoreCase(optionId, searchVal)
+      : optionId.includes(searchVal);
   }
 
   function hasText() {

--- a/src/components/search-bar/search-bar.tsx
+++ b/src/components/search-bar/search-bar.tsx
@@ -102,11 +102,11 @@ export const SearchBar = ({
   }
 
   function optionIncludesValueFilter(option: DropDownOption<string>) {
-    const optionId = option.id;
+    const optionVal = option.value as string;
     const searchVal = value.trim();
     return dropDownIgnoreCase
-      ? includesIgnoreCase(optionId, searchVal)
-      : optionId.includes(searchVal);
+      ? includesIgnoreCase(optionVal, searchVal)
+      : optionVal.includes(searchVal);
   }
 
   function hasText() {

--- a/src/components/search-bar/search-bar.tsx
+++ b/src/components/search-bar/search-bar.tsx
@@ -13,13 +13,13 @@ export interface SearchBarProps {
   initialText?: string;
   placeholder?: string;
   disabled?: boolean;
-  dropDownData?: DropDownOption<string>[];
+  dropDownData?: DropDownOption<string, string>[];
   dropDownIgnoreCase?: boolean;
   debounceMs?: number;
   onChange?: (value: string) => void;
   onEnterPressed?: (value: string) => void;
   onDebouncedChange?: (value: string) => void;
-  onDropdownClick?: (option: DropDownOption<string>) => void;
+  onDropdownClick?: (option: DropDownOption<string, string>) => void;
 }
 
 export const SearchBar = ({
@@ -101,8 +101,8 @@ export const SearchBar = ({
     );
   }
 
-  function optionIncludesValueFilter(option: DropDownOption<string>) {
-    const optionVal = option.value as string;
+  function optionIncludesValueFilter(option: DropDownOption<string, string>) {
+    const optionVal = option.value;
     const searchVal = value.trim();
     return dropDownIgnoreCase
       ? includesIgnoreCase(optionVal, searchVal)

--- a/src/layouts/sidebar-layout/sidebar-layout.scss
+++ b/src/layouts/sidebar-layout/sidebar-layout.scss
@@ -11,20 +11,20 @@ $content-height: calc(100vh - #{$header-height + $content-padding});
 .sidebar-layout-header {
   .c-header-content {
     .c-header-title {
-      @media screen and (max-width: $medium-screen) {
+      @media screen and (max-width: $large-screen) {
         flex: 1;
       }
     }
 
     .c-header-title {
-      @media screen and (max-width: $medium-screen) {
+      @media screen and (max-width: $large-screen) {
         flex: 1;
         padding: unset;
       }
     }
 
     .c-account-buttons {
-      @media screen and (max-width: $medium-screen) {
+      @media screen and (max-width: $large-screen) {
         flex: 1;
       }
     }
@@ -32,12 +32,12 @@ $content-height: calc(100vh - #{$header-height + $content-padding});
 }
 
 .sidebar-layout-sidebar {
-  @media screen and (max-width: $large-screen) {
+  @media screen and (max-width: $giant-screen) {
     padding-left: unset;
     width: $sidebar-width / 1.15;
   }
 
-  @media screen and (max-width: $medium-screen) {
+  @media screen and (max-width: $large-screen) {
     display: none;
   }
 }
@@ -47,11 +47,11 @@ $content-height: calc(100vh - #{$header-height + $content-padding});
   margin-left: $sidebar-width;
   padding-top: $header-height;
 
-  @media screen and (max-width: $large-screen) {
+  @media screen and (max-width: $giant-screen) {
     margin-left: ($sidebar-width / 1.15);
   }
 
-  @media screen and (max-width: $medium-screen) {
+  @media screen and (max-width: $large-screen) {
     margin-left: 0;
   }
 
@@ -64,7 +64,7 @@ $content-height: calc(100vh - #{$header-height + $content-padding});
     max-width: 1700px;
     margin: auto;
 
-    @media screen and (max-width: $medium-screen) {
+    @media screen and (max-width: $large-screen) {
       height: calc($content-height + 16px); // to offset flashcard-decks margin shrinking
       padding: 16px ($content-padding / 2);
     }

--- a/src/layouts/sidebar-layout/sidebar-layout.tsx
+++ b/src/layouts/sidebar-layout/sidebar-layout.tsx
@@ -15,8 +15,8 @@ export const SidebarLayout = () => {
     if (!navToggled) return;
 
     const resizeHandler = throttle(() => {
-      // if greater than medium size (768px), hide nav
-      if (window.innerWidth > 768) {
+      // if greater than large size (1024px), hide nav
+      if (window.innerWidth > 1024) {
         setNavToggled(false);
       }
     }, 250);

--- a/src/models/lesson-card.ts
+++ b/src/models/lesson-card.ts
@@ -3,7 +3,9 @@ import { CardContent } from './card-content';
 import { Deck } from './deck';
 import { DeckLanguage } from './language';
 
-export type LessonCardOutcome = 'unseen' | 'correct' | 'incorrect';
+export const LessonCardOutcomes = ['correct', 'unseen', 'incorrect'] as const;
+
+export type LessonCardOutcome = typeof LessonCardOutcomes[number];
 
 export interface LessonCard extends Card {
   front: LessonCardContent;

--- a/src/models/mock/card.mock.ts
+++ b/src/models/mock/card.mock.ts
@@ -2,6 +2,7 @@ import {
   getTestFoxBack,
   getTestFoxFront,
   getTestMonkeyFront,
+  getTestMonkeyBack,
   getTestMouseBack,
   getTestMouseFront,
 } from './card-content.mock';
@@ -28,7 +29,7 @@ export const getTestMouseCard = (score?: number, dateUpdated?: Date): Card => {
 export const getTestMonkeyCard = (score?: number, dateUpdated?: Date): Card => {
   const testCard = createNewCard();
   testCard.front = getTestMonkeyFront();
-  testCard.back = getTestMouseBack();
+  testCard.back = getTestMonkeyBack();
   testCard.score = score ?? 0;
   testCard.dateUpdated = dateUpdated ?? testCard.dateUpdated;
   return testCard;

--- a/src/pages/decks/flashcard-decks.tsx
+++ b/src/pages/decks/flashcard-decks.tsx
@@ -44,7 +44,7 @@ export const FlashcardDecksPage = () => {
           options={AllSortRules.map((item) => ({ id: item, value: item, focusable: true }))}
           label="sort by"
           buttonLabel={sortOption}
-          onOptionSelect={(option) => setSortOption(option.value)}
+          onOptionSelect={(option) => setSortOption(option.id)}
         />
       </div>
       <div className="deck-tile-container">

--- a/src/pages/study-page/study-page.tsx
+++ b/src/pages/study-page/study-page.tsx
@@ -40,7 +40,14 @@ export const StudyPage = ({ deck }: StudyPageProps) => {
     return <StudyLessonPage deck={deck} onLessonComplete={handleLessonComplete} />;
   }
   function getStudyLessonResultsPage() {
-    return <StudyResultsPage lessonCards={lessonCards} deck={deck} lessonTime={lessonTime} />;
+    return (
+      <StudyResultsPage
+        lessonCards={lessonCards}
+        deck={deck}
+        lessonTime={lessonTime}
+        onLessonCardsChange={setLessonCards}
+      />
+    );
   }
 
   function handleLessonComplete(lessonCards: LessonCard[], lessonTime: number) {

--- a/src/pages/study-page/study-results-page/study-result-cards/study-result-cards.scss
+++ b/src/pages/study-page/study-results-page/study-result-cards/study-result-cards.scss
@@ -1,0 +1,22 @@
+@import '../../../../assets/colors';
+@import '../../../../assets/styles';
+
+.study-results-flashcard-container {
+  @include flex-center;
+  width: 100%;
+
+  .study-results-flashcard-icon {
+    width: 60px;
+    padding-right: 10px;
+    @include flex-center;
+
+    @media screen and (max-width: $medium-screen) {
+      padding: 0px;
+    }
+
+    .study-results-card-option {
+      @include flex-center;
+      padding: 8px;
+    }
+  }
+}

--- a/src/pages/study-page/study-results-page/study-result-cards/study-result-cards.test.tsx
+++ b/src/pages/study-page/study-results-page/study-result-cards/study-result-cards.test.tsx
@@ -15,14 +15,11 @@ const MARK_AS_INCORRECT_LABEL = 'mark as incorrect';
 const MARK_AS_SKIPPED_LABEL = 'mark as skipped';
 
 describe('StudyResultCards', () => {
-  let testDeck: Deck;
   let testLessonCards: LessonCard[];
 
   beforeEach(() => {
-    testDeck = createNewDeck();
-
     const testCards = [getTestFoxCard(), getTestMonkeyCard(), getTestMouseCard()];
-    testLessonCards = testCards.map((card) => createNewLessonCard(card, testDeck, 1));
+    testLessonCards = testCards.map((card) => createNewLessonCard(card, createNewDeck(), 1));
   });
 
   it('should render correctly with default props', () => {

--- a/src/pages/study-page/study-results-page/study-result-cards/study-result-cards.test.tsx
+++ b/src/pages/study-page/study-results-page/study-result-cards/study-result-cards.test.tsx
@@ -1,0 +1,94 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { noop } from '../../../../helpers/func';
+import { createNewDeck, Deck } from '../../../../models/deck';
+import { createNewLessonCard, LessonCard } from '../../../../models/lesson-card';
+import {
+  getTestFoxCard,
+  getTestMonkeyCard,
+  getTestMouseCard,
+} from '../../../../models/mock/card.mock';
+import { StudyResultCards } from './study-result-cards';
+
+const MARK_AS_CORRECT_LABEL = 'mark as correct';
+const MARK_AS_INCORRECT_LABEL = 'mark as incorrect';
+const MARK_AS_SKIPPED_LABEL = 'mark as skipped';
+
+describe('StudyResultCards', () => {
+  let testDeck: Deck;
+  let testLessonCards: LessonCard[];
+
+  beforeEach(() => {
+    testDeck = createNewDeck();
+
+    const testCards = [getTestFoxCard(), getTestMonkeyCard(), getTestMouseCard()];
+    testLessonCards = testCards.map((card) => createNewLessonCard(card, testDeck, 1));
+  });
+
+  it('should render correctly with default props', () => {
+    render(<StudyResultCards lessonCards={testLessonCards} onLessonCardsChange={noop} />);
+
+    for (const card of testLessonCards) {
+      expect(screen.queryByText(card.front.text)).toBeInTheDocument();
+      expect(screen.queryByText(card.back.text)).toBeInTheDocument();
+    }
+    const numCards = testLessonCards.length;
+    expect(screen.queryAllByRole('button', { name: 'kebab-menu' }).length).toEqual(numCards);
+    expect(screen.queryAllByRole('graphics-document', { name: 'skipped' }).length).toEqual(
+      numCards
+    );
+  });
+
+  it('should show all outcome icons', () => {
+    testLessonCards[0].outcome = 'correct';
+    testLessonCards[1].outcome = 'incorrect';
+    testLessonCards[2].outcome = 'unseen';
+    render(<StudyResultCards lessonCards={testLessonCards} onLessonCardsChange={noop} />);
+
+    expect(screen.queryByRole('graphics-document', { name: 'skipped' })).toBeInTheDocument();
+    expect(screen.queryByRole('graphics-document', { name: 'correct' })).toBeInTheDocument();
+    expect(screen.queryByRole('graphics-document', { name: 'incorrect' })).toBeInTheDocument();
+  });
+
+  it('menu should show all options besides current outcome', () => {
+    const { rerender } = render(
+      <StudyResultCards lessonCards={[testLessonCards[0]]} onLessonCardsChange={noop} />
+    );
+
+    userEvent.click(screen.getByRole('button', { name: 'kebab-menu' }));
+
+    expect(screen.queryByText(MARK_AS_CORRECT_LABEL)).toBeInTheDocument();
+    expect(screen.queryByText(MARK_AS_INCORRECT_LABEL)).toBeInTheDocument();
+    expect(screen.queryByText(MARK_AS_SKIPPED_LABEL)).not.toBeInTheDocument();
+
+    testLessonCards[0] = { ...testLessonCards[0], outcome: 'correct' };
+    rerender(<StudyResultCards lessonCards={[testLessonCards[0]]} onLessonCardsChange={noop} />);
+
+    expect(screen.queryByText(MARK_AS_INCORRECT_LABEL)).toBeInTheDocument();
+    expect(screen.queryByText(MARK_AS_SKIPPED_LABEL)).toBeInTheDocument();
+    expect(screen.queryByText(MARK_AS_CORRECT_LABEL)).not.toBeInTheDocument();
+
+    testLessonCards[0] = { ...testLessonCards[0], outcome: 'incorrect' };
+    rerender(<StudyResultCards lessonCards={[testLessonCards[0]]} onLessonCardsChange={noop} />);
+
+    expect(screen.queryByText(MARK_AS_CORRECT_LABEL)).toBeInTheDocument();
+    expect(screen.queryByText(MARK_AS_SKIPPED_LABEL)).toBeInTheDocument();
+    expect(screen.queryByText(MARK_AS_INCORRECT_LABEL)).not.toBeInTheDocument();
+  });
+
+  it('should call onLessonCardsChange when outcome is overridden', () => {
+    const mockOnLessCardsChange = jest.fn<void, [LessonCard[]]>();
+    render(
+      <StudyResultCards
+        lessonCards={[testLessonCards[0]]}
+        onLessonCardsChange={mockOnLessCardsChange}
+      />
+    );
+
+    userEvent.click(screen.getByRole('button', { name: 'kebab-menu' }));
+    userEvent.click(screen.getByText(MARK_AS_CORRECT_LABEL));
+
+    const expectedCard = { ...testLessonCards[0], outcome: 'correct' };
+    expect(mockOnLessCardsChange).toHaveBeenCalledWith([expectedCard]);
+  });
+});

--- a/src/pages/study-page/study-results-page/study-result-cards/study-result-cards.tsx
+++ b/src/pages/study-page/study-results-page/study-result-cards/study-result-cards.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { ReactNode, useState } from 'react';
 import { CorrectIcon } from '../../../../assets/icons/correct-icon/correct-icon';
 import { IncorrectIcon } from '../../../../assets/icons/incorrect-icon/incorrect-icon';
 import { SkippedIcon } from '../../../../assets/icons/skipped-icon/skipped-icon';
@@ -71,10 +71,12 @@ export const StudyResultCards = ({ lessonCards, onLessonCardsChange }: StudyResu
       unseen: 'mark as skipped',
     };
 
-    const options: DropDownOption<LessonCardOutcome>[] = LessonCardOutcomes.map((outcome) => {
-      const value = <div className="study-results-card-option">{optionsText[outcome]}</div>;
-      return { id: outcome, focusable: true, value };
-    });
+    const options: DropDownOption<LessonCardOutcome, ReactNode>[] = LessonCardOutcomes.map(
+      (outcome) => {
+        const value = <div className="study-results-card-option">{optionsText[outcome]}</div>;
+        return { id: outcome, focusable: true, value };
+      }
+    );
 
     return options.filter((option) => option.id !== outcome);
   }
@@ -86,7 +88,10 @@ export const StudyResultCards = ({ lessonCards, onLessonCardsChange }: StudyResu
     setOpenMenuCardKey(isOpen ? cardKey : '');
   }
 
-  function handleOptionSelect(option: DropDownOption<LessonCardOutcome>, cardKey: string) {
+  function handleOptionSelect(
+    option: DropDownOption<LessonCardOutcome, ReactNode>,
+    cardKey: string
+  ) {
     const index = lessonCards.findIndex((card) => card.key === cardKey);
     const newLessonCards = [...lessonCards];
     newLessonCards[index] = { ...newLessonCards[index], outcome: option.id };

--- a/src/pages/study-page/study-results-page/study-result-cards/study-result-cards.tsx
+++ b/src/pages/study-page/study-results-page/study-result-cards/study-result-cards.tsx
@@ -1,0 +1,97 @@
+import React, { useState } from 'react';
+import { CorrectIcon } from '../../../../assets/icons/correct-icon/correct-icon';
+import { IncorrectIcon } from '../../../../assets/icons/incorrect-icon/incorrect-icon';
+import { SkippedIcon } from '../../../../assets/icons/skipped-icon/skipped-icon';
+import { DropDownOption } from '../../../../components/drop-down-options/drop-down-options';
+import { KebabMenu } from '../../../../components/kebab-menu/kebab-menu';
+import {
+  ReadOnlyFlashcard,
+  ReadOnlyFlashcardVariant,
+} from '../../../../components/read-only-flashcard/read-only-flashcard';
+import { useLazyAudioPlayer } from '../../../../hooks/use-lazy-audio-player';
+import { LessonCard, LessonCardOutcome, LessonCardOutcomes } from '../../../../models/lesson-card';
+import './study-result-cards.scss';
+
+interface StudyResultCardsProps {
+  lessonCards: LessonCard[];
+  onLessonCardsChange: (lessCards: LessonCard[]) => void;
+}
+
+export const StudyResultCards = ({ lessonCards, onLessonCardsChange }: StudyResultCardsProps) => {
+  const [openMenuCardKey, setOpenMenuCardKey] = useState('');
+  const { playLazyAudio } = useLazyAudioPlayer();
+
+  const variants: Record<LessonCardOutcome, ReadOnlyFlashcardVariant> = {
+    correct: 'green',
+    incorrect: 'red',
+    unseen: 'light-blue',
+  };
+
+  const icons: Record<LessonCardOutcome, React.ReactNode> = {
+    correct: <CorrectIcon />,
+    incorrect: <IncorrectIcon />,
+    unseen: <SkippedIcon />,
+  };
+
+  return (
+    <>
+      {lessonCards.map((card) => {
+        const icon = icons[card.outcome];
+        const variant = variants[card.outcome];
+        return (
+          <div key={card.key} className="study-results-flashcard-container">
+            <div className="study-results-flashcard-icon">{icon}</div>
+            <ReadOnlyFlashcard
+              className="study-results-flashcard"
+              variant={variant}
+              frontText={card.front.text}
+              backText={card.back.text}
+              onFrontSpeakerClick={() => playLazyAudio(card.front.audio)}
+              onBackSpeakerClick={() => playLazyAudio(card.back.audio)}
+            />
+            <div className="study-results-flashcard-icon">
+              <KebabMenu
+                variant={variant}
+                isOpen={card.key === openMenuCardKey}
+                setIsOpen={(isOpen) => handleSetIsOpen(isOpen, card.key)}
+                onOptionSelect={(option) => handleOptionSelect(option, card.key)}
+                options={getOptions(card.outcome)}
+              />
+            </div>
+          </div>
+        );
+      })}
+    </>
+  );
+
+  function getOptions(outcome: LessonCardOutcome) {
+    const optionsText: Record<LessonCardOutcome, string> = {
+      correct: 'mark as correct',
+      incorrect: 'mark as incorrect',
+      unseen: 'mark as skipped',
+    };
+
+    const options: DropDownOption<LessonCardOutcome>[] = LessonCardOutcomes.map((outcome) => {
+      const value = <div className="study-results-card-option">{optionsText[outcome]}</div>;
+      return { id: outcome, focusable: true, value };
+    });
+
+    return options.filter((option) => option.id !== outcome);
+  }
+
+  function handleSetIsOpen(isOpen: boolean, cardKey: string) {
+    if (!isOpen && openMenuCardKey !== cardKey) {
+      return;
+    }
+    setOpenMenuCardKey(isOpen ? cardKey : '');
+  }
+
+  function handleOptionSelect(option: DropDownOption<LessonCardOutcome>, cardKey: string) {
+    const index = lessonCards.findIndex((card) => card.key === cardKey);
+    const newLessonCards = [...lessonCards];
+    newLessonCards[index] = { ...newLessonCards[index], outcome: option.id };
+
+    onLessonCardsChange(newLessonCards);
+    setOpenMenuCardKey('');
+  }
+};

--- a/src/pages/study-page/study-results-page/study-results-page.scss
+++ b/src/pages/study-page/study-results-page/study-results-page.scss
@@ -1,8 +1,6 @@
 @import '../../../assets/colors';
 @import '../../../assets/styles';
 
-$flashcard-icon-width: 60px;
-
 .study-results-page {
   @include flex-center;
   flex-direction: column;
@@ -77,20 +75,5 @@ $flashcard-icon-width: 60px;
   .studied-cards-divider {
     width: 100%;
     margin: 20px 0px;
-  }
-
-  .study-results-flashcard-container {
-    @include flex-center;
-    width: 100%;
-
-    .study-results-flashcard-icon {
-      width: $flashcard-icon-width;
-      padding-right: 10px;
-      @include flex-center;
-    }
-
-    .study-results-flashcard {
-      margin-right: $flashcard-icon-width;
-    }
   }
 }

--- a/src/pages/study-page/study-results-page/study-results-page.tsx
+++ b/src/pages/study-page/study-results-page/study-results-page.tsx
@@ -1,32 +1,30 @@
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
+import { StudyResultCards } from './study-result-cards/study-result-cards';
 import { CardStackIcon } from '../../../assets/icons/card-stack-icon/card-stack-icon';
 import { ClockIcon } from '../../../assets/icons/clock-icon/clock-icon';
-import { CorrectIcon } from '../../../assets/icons/correct-icon/correct-icon';
-import { IncorrectIcon } from '../../../assets/icons/incorrect-icon/incorrect-icon';
-import { SkippedIcon } from '../../../assets/icons/skipped-icon/skipped-icon';
 import { StarIcon } from '../../../assets/icons/star-con/star-icon';
 import { BubbleDivider } from '../../../components/bubble-divider/bubble-divider';
 import { Button } from '../../../components/button/button';
-import {
-  ReadOnlyFlashcard,
-  ReadOnlyFlashcardVariant,
-} from '../../../components/read-only-flashcard/read-only-flashcard';
 import { getFormattedMilliseconds } from '../../../helpers/time';
-import { useLazyAudioPlayer } from '../../../hooks/use-lazy-audio-player';
 import { Deck } from '../../../models/deck';
-import { LessonCard, LessonCardOutcome } from '../../../models/lesson-card';
+import { LessonCard } from '../../../models/lesson-card';
 import { paths } from '../../../routing/paths';
 import './study-results-page.scss';
 
 interface StudyResultsPageProps {
   deck: Deck;
   lessonCards: LessonCard[];
+  onLessonCardsChange: (lessonCards: LessonCard[]) => void;
   lessonTime: number;
 }
 
-export const StudyResultsPage = ({ deck, lessonCards, lessonTime }: StudyResultsPageProps) => {
-  const { playLazyAudio } = useLazyAudioPlayer();
+export const StudyResultsPage = ({
+  deck,
+  lessonCards,
+  lessonTime,
+  onLessonCardsChange,
+}: StudyResultsPageProps) => {
   const navigate = useNavigate();
 
   const title = `${deck.metaData.title} Lesson Results`;
@@ -46,7 +44,7 @@ export const StudyResultsPage = ({ deck, lessonCards, lessonTime }: StudyResults
         variantType="divider"
         label="studied cards"
       />
-      {getLessonCards()}
+      <StudyResultCards lessonCards={lessonCards} onLessonCardsChange={onLessonCardsChange} />
     </div>
   );
 
@@ -93,37 +91,5 @@ export const StudyResultsPage = ({ deck, lessonCards, lessonTime }: StudyResults
         </div>
       </>
     );
-  }
-
-  function getLessonCards() {
-    const icons: Record<LessonCardOutcome, React.ReactNode> = {
-      correct: <CorrectIcon />,
-      incorrect: <IncorrectIcon />,
-      unseen: <SkippedIcon />,
-    };
-
-    const variants: Record<LessonCardOutcome, ReadOnlyFlashcardVariant> = {
-      correct: 'green',
-      incorrect: 'red',
-      unseen: 'light-blue',
-    };
-
-    return lessonCards.map((card) => {
-      const icon = icons[card.outcome];
-      const variant = variants[card.outcome];
-      return (
-        <div key={card.key} className="study-results-flashcard-container">
-          <div className="study-results-flashcard-icon">{icon}</div>
-          <ReadOnlyFlashcard
-            className="study-results-flashcard"
-            variant={variant}
-            frontText={card.front.text}
-            backText={card.back.text}
-            onFrontSpeakerClick={() => playLazyAudio(card.front.audio)}
-            onBackSpeakerClick={() => playLazyAudio(card.back.audio)}
-          />
-        </div>
-      );
-    });
   }
 };

--- a/src/pages/view-deck-page/view-deck-page.scss
+++ b/src/pages/view-deck-page/view-deck-page.scss
@@ -1,4 +1,8 @@
 @import '../../assets/colors';
+@import '../../assets/styles';
+
+$flashcard-index-container-width: 45px;
+
 .view-deck-page {
   width: 100%;
   color: $white;
@@ -20,5 +24,32 @@
 
   .empty-card-set-placeholder {
     text-align: center;
+  }
+
+  .view-deck-flashcard-container {
+    @include flex-center;
+
+    .view-deck-flashcard {
+      margin-right: $flashcard-index-container-width;
+    }
+
+    .view-deck-flashcard-index {
+      display: flex;
+      color: $light-blue;
+      font-size: 20px;
+      width: $flashcard-index-container-width;
+    }
+
+    @media screen and (max-width: $medium-screen) {
+      $flashcard-index-container-width: 25px;
+
+      .view-deck-flashcard {
+        margin-right: $flashcard-index-container-width;
+      }
+
+      .view-deck-flashcard-index {
+        width: $flashcard-index-container-width;
+      }
+    }
   }
 }

--- a/src/pages/view-deck-page/view-deck-page.tsx
+++ b/src/pages/view-deck-page/view-deck-page.tsx
@@ -48,15 +48,18 @@ export const ViewDeckPage = ({ deck }: ViewDeckPageProps) => {
   );
 
   function getFlashcards() {
-    return deck.cards.map((card) => (
-      <ReadOnlyFlashcard
-        key={card.key}
-        variant="light-blue"
-        frontText={card.front.text}
-        backText={card.back.text}
-        onFrontSpeakerClick={() => playLazyAudio(card.front.audio)}
-        onBackSpeakerClick={() => playLazyAudio(card.back.audio)}
-      />
+    return deck.cards.map((card, index) => (
+      <div className="view-deck-flashcard-container" key={card.key}>
+        <div className="view-deck-flashcard-index">{`${index + 1}.`}</div>
+        <ReadOnlyFlashcard
+          className="view-deck-flashcard"
+          variant="light-blue"
+          frontText={card.front.text}
+          backText={card.back.text}
+          onFrontSpeakerClick={() => playLazyAudio(card.front.audio)}
+          onBackSpeakerClick={() => playLazyAudio(card.back.audio)}
+        />
+      </div>
     ));
   }
 


### PR DESCRIPTION
## Summary of Changes##
- Added roles to `correct`, `incorrect`, and `skipped` icons for accessibility and testing
- Set `DropDownOption` generic to be on the `id` instead of `value`
- Added kebab menu to study results cards to override card outcome
  - kinda plain, might polish in future
-  broke study-results-cards into a separate component
- Readonly cards now break into two lines for small screens
  - Added index on view deck page cards to help tie card faces together  

https://user-images.githubusercontent.com/39753553/191891884-f35477aa-8d05-4632-8070-91b4c7f9d2f4.mov

