### PR TITLE
feat: add account popup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "react-scripts": "5.0.0",
         "react-textarea-autosize": "^8.3.4",
         "recoil": "^0.7.2",
+        "ts-md5": "^1.3.1",
         "uuid": "^8.3.2",
         "web-vitals": "^2.1.4"
       },
@@ -17986,6 +17987,14 @@
       "resolved": "https://registry.npmjs.org/tryer/-/tryer-1.0.1.tgz",
       "integrity": "sha512-c3zayb8/kWWpycWYg87P71E1S1ZL6b6IJxfb5fvsUgsf0S2MVGaDhDXXjDMpdCpfWXqptc+4mXwmiy1ypXqRAA=="
     },
+    "node_modules/ts-md5": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/ts-md5/-/ts-md5-1.3.1.tgz",
+      "integrity": "sha512-DiwiXfwvcTeZ5wCE0z+2A9EseZsztaiZtGrtSaY5JOD7ekPnR/GoIVD5gXZAlK9Na9Kvpo9Waz5rW64WKAWApg==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/ts-node": {
       "version": "10.9.1",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
@@ -32226,6 +32235,11 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/tryer/-/tryer-1.0.1.tgz",
       "integrity": "sha512-c3zayb8/kWWpycWYg87P71E1S1ZL6b6IJxfb5fvsUgsf0S2MVGaDhDXXjDMpdCpfWXqptc+4mXwmiy1ypXqRAA=="
+    },
+    "ts-md5": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/ts-md5/-/ts-md5-1.3.1.tgz",
+      "integrity": "sha512-DiwiXfwvcTeZ5wCE0z+2A9EseZsztaiZtGrtSaY5JOD7ekPnR/GoIVD5gXZAlK9Na9Kvpo9Waz5rW64WKAWApg=="
     },
     "ts-node": {
       "version": "10.9.1",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "react-scripts": "5.0.0",
     "react-textarea-autosize": "^8.3.4",
     "recoil": "^0.7.2",
+    "ts-md5": "^1.3.1",
     "uuid": "^8.3.2",
     "web-vitals": "^2.1.4"
   },

--- a/src/assets/_styles.scss
+++ b/src/assets/_styles.scss
@@ -11,6 +11,7 @@ $giant-screen: 1280px;
 $standard-radius: 8px;
 $sidebar-width: 260px;
 $header-height: 53px;
+$header-gap: 16px;
 $content-padding: 50px;
 
 $z-sidebar: 32;

--- a/src/components/drop-down/drop-down.tsx
+++ b/src/components/drop-down/drop-down.tsx
@@ -28,7 +28,7 @@ export const DropDown = <T extends React.ReactNode>({
   const accentVariant = variant === 'dark' ? 'light' : 'dark';
 
   const dropDownMenuRef = useRef(null);
-  useOutsideClick(dropDownMenuRef, () => setIsOpen(false));
+  useOutsideClick(dropDownMenuRef, () => setIsOpen(false), isOpen);
   useFocusTrap(dropDownMenuRef, isOpen);
   useEscapePress(() => setIsOpen(false), isOpen);
 

--- a/src/components/drop-down/drop-down.tsx
+++ b/src/components/drop-down/drop-down.tsx
@@ -1,6 +1,7 @@
 import React, { useRef, useState } from 'react';
 import { ArrowIcon } from '../../assets/icons/arrow-icon/arrow-icon';
 import { useFocusTrap } from '../../hooks/use-focus-trap';
+import { useEscapePress } from '../../hooks/use-key-press';
 import { useOutsideClick } from '../../hooks/use-outside-click';
 import { Button } from '../button/button';
 import { DropDownOption, DropDownOptions } from '../drop-down-options/drop-down-options';
@@ -29,6 +30,7 @@ export const DropDown = <T extends React.ReactNode>({
   const dropDownMenuRef = useRef(null);
   useOutsideClick(dropDownMenuRef, () => setIsOpen(false));
   useFocusTrap(dropDownMenuRef, isOpen);
+  useEscapePress(() => setIsOpen(false), isOpen);
 
   return (
     <div className={`drop-down ${className}`}>

--- a/src/components/header/account-popup/account-popup.scss
+++ b/src/components/header/account-popup/account-popup.scss
@@ -1,0 +1,49 @@
+@import url('https://fonts.googleapis.com/css2?family=Comfortaa:wght@300;700&display=swap');
+@import '../../../assets/colors';
+@import '../../../assets/styles';
+
+$bg-opacity: 0; // opacity to set background if modal is open
+
+.c-account-popup-overlay {
+  z-index: $z-popup-modal;
+  position: fixed;
+  inset: 0;
+  min-width: 100%;
+  min-height: 100%;
+  background-color: rgba(0, 0, 0, $bg-opacity);
+  transition: visibility 150ms ease-out, opacity 150ms ease-out;
+
+  &.visible {
+    visibility: visible;
+    opacity: 1;
+  }
+
+  &.hidden {
+    visibility: hidden;
+    opacity: 0;
+  }
+}
+
+.c-account-popup-content {
+  z-index: $z-popup-modal;
+  position: absolute;
+  right: $header-gap;
+  top: 1px;
+  background: $white;
+  padding: 8px 16px;
+  border-radius: $standard-radius;
+
+  @media screen and (max-width: $small-screen) {
+    right: 0;
+  }
+
+  .c-popup-modal-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    color: $blue;
+    font-family: 'Comfortaa';
+    font-weight: bold;
+    font-size: 20px;
+  }
+}

--- a/src/components/header/account-popup/account-popup.scss
+++ b/src/components/header/account-popup/account-popup.scss
@@ -6,7 +6,7 @@ $bg-opacity: 0; // opacity to set background if modal is open
 
 .c-account-popup-overlay {
   z-index: $z-popup-modal;
-  position: fixed;
+  position: absolute;
   right: 0;
   top: 0;
   background-color: rgba(0, 0, 0, $bg-opacity);

--- a/src/components/header/account-popup/account-popup.scss
+++ b/src/components/header/account-popup/account-popup.scss
@@ -34,14 +34,4 @@ $bg-opacity: 0; // opacity to set background if modal is open
   @media screen and (max-width: $small-screen) {
     right: 0;
   }
-
-  .c-popup-modal-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    color: $blue;
-    font-family: 'Comfortaa';
-    font-weight: bold;
-    font-size: 20px;
-  }
 }

--- a/src/components/header/account-popup/account-popup.scss
+++ b/src/components/header/account-popup/account-popup.scss
@@ -7,9 +7,8 @@ $bg-opacity: 0; // opacity to set background if modal is open
 .c-account-popup-overlay {
   z-index: $z-popup-modal;
   position: fixed;
-  inset: 0;
-  min-width: 100%;
-  min-height: 100%;
+  right: 0;
+  top: 0;
   background-color: rgba(0, 0, 0, $bg-opacity);
   transition: visibility 150ms ease-out, opacity 150ms ease-out;
 
@@ -30,8 +29,7 @@ $bg-opacity: 0; // opacity to set background if modal is open
   right: $header-gap;
   top: 1px;
   background: $white;
-  padding: 8px 16px;
-  border-radius: $standard-radius;
+  border-radius: $standard-radius * 0.75;
 
   @media screen and (max-width: $small-screen) {
     right: 0;

--- a/src/components/header/account-popup/account-popup.test.tsx
+++ b/src/components/header/account-popup/account-popup.test.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import { fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { AccountPopup } from './account-popup';
+import { renderWithTestRoots } from '../../../app.test';
+import { noop } from '../../../helpers/func';
+
+describe('AccountPopup', () => {
+  const DEFAULT_CHILDREN = <div>test123</div>;
+
+  beforeEach(() => {
+    // setup portal element for modal to render on
+    document.body.innerHTML = `<div id="portal"></div>`;
+  });
+
+  it('should render correctly with default props', () => {
+    renderWithTestRoots(
+      <AccountPopup showTrigger={true} onClose={noop}>
+        {DEFAULT_CHILDREN}
+      </AccountPopup>
+    );
+    expectPopupIsVisible();
+  });
+
+  it('should hide when show is not triggered', () => {
+    renderWithTestRoots(
+      <AccountPopup showTrigger={false} onClose={noop}>
+        {DEFAULT_CHILDREN}
+      </AccountPopup>
+    );
+    expectPopupIsHidden();
+  });
+
+  it('should close itself on outside click', () => {
+    const mockOnClose = jest.fn();
+    renderWithTestRoots(
+      <AccountPopup showTrigger={true} onClose={mockOnClose}>
+        {DEFAULT_CHILDREN}
+      </AccountPopup>
+    );
+    expect(mockOnClose).not.toBeCalled();
+
+    // simulate clicking outside modal
+    userEvent.click(document.body);
+    expect(mockOnClose).toBeCalled();
+  });
+
+  it('should close itself on Escape pressed', () => {
+    const mockOnClose = jest.fn();
+    renderWithTestRoots(
+      <AccountPopup showTrigger={true} onClose={mockOnClose}>
+        {DEFAULT_CHILDREN}
+      </AccountPopup>
+    );
+    expect(mockOnClose).not.toBeCalled();
+
+    // simulate pressing Escape
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(mockOnClose).toBeCalled();
+  });
+
+  function expectPopupIsHidden() {
+    const wrapper = document.querySelector('.c-account-popup-overlay');
+    expect(wrapper).toHaveClass('hidden');
+  }
+
+  function expectPopupIsVisible() {
+    const wrapper = document.querySelector('.c-account-popup-overlay');
+    expect(wrapper).toHaveClass('visible');
+  }
+});

--- a/src/components/header/account-popup/account-popup.tsx
+++ b/src/components/header/account-popup/account-popup.tsx
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom';
 import { CancelIcon } from '../../../assets/icons/cancel-icon/cancel-icon';
 import { useFocusFirst } from '../../../hooks/use-focus-first';
 import { useFocusTrap } from '../../../hooks/use-focus-trap';
+import { useEscapePress } from '../../../hooks/use-key-press';
 import { useOutsideClick } from '../../../hooks/use-outside-click';
 import './account-popup.scss';
 
@@ -10,7 +11,6 @@ export interface AccountPopupProps {
   className?: string;
   children: React.ReactNode;
   showTrigger: boolean;
-  outsideClickFiresOnClose?: boolean;
   onClose: () => void;
 }
 
@@ -18,13 +18,13 @@ export const AccountPopup = ({
   className = '',
   children,
   showTrigger,
-  outsideClickFiresOnClose = false,
   onClose,
 }: AccountPopupProps) => {
   const contentRef = useRef<HTMLDivElement>(null);
 
-  useOutsideClick(contentRef, () => onClose(), outsideClickFiresOnClose);
+  useOutsideClick(contentRef, () => onClose());
   useFocusTrap(contentRef, showTrigger);
+  useEscapePress(() => onClose(), showTrigger);
 
   const showClass = showTrigger ? 'visible' : 'hidden';
 

--- a/src/components/header/account-popup/account-popup.tsx
+++ b/src/components/header/account-popup/account-popup.tsx
@@ -1,0 +1,42 @@
+import React, { useRef } from 'react';
+import ReactDOM from 'react-dom';
+import { CancelIcon } from '../../../assets/icons/cancel-icon/cancel-icon';
+import { useFocusFirst } from '../../../hooks/use-focus-first';
+import { useFocusTrap } from '../../../hooks/use-focus-trap';
+import { useOutsideClick } from '../../../hooks/use-outside-click';
+import './account-popup.scss';
+
+export interface AccountPopupProps {
+  className?: string;
+  children: React.ReactNode;
+  showTrigger: boolean;
+  outsideClickFiresOnClose?: boolean;
+  onClose: () => void;
+}
+
+export const AccountPopup = ({
+  className = '',
+  children,
+  showTrigger,
+  outsideClickFiresOnClose = false,
+  onClose,
+}: AccountPopupProps) => {
+  const contentRef = useRef<HTMLDivElement>(null);
+
+  useOutsideClick(contentRef, () => onClose(), outsideClickFiresOnClose);
+  useFocusTrap(contentRef, showTrigger);
+
+  const showClass = showTrigger ? 'visible' : 'hidden';
+
+  // render onto <div id="portal"></div> instead of in parent hierarchy but still propagate events
+  return ReactDOM.createPortal(
+    <>
+      <div className={`c-account-popup-overlay ${showClass}`}>
+        <div className={`c-account-popup-content ${className}`} ref={contentRef}>
+          {children}
+        </div>
+      </div>
+    </>,
+    document.getElementById('portal') as HTMLElement
+  );
+};

--- a/src/components/header/account-popup/account-popup.tsx
+++ b/src/components/header/account-popup/account-popup.tsx
@@ -22,7 +22,7 @@ export const AccountPopup = ({
 }: AccountPopupProps) => {
   const contentRef = useRef<HTMLDivElement>(null);
 
-  useOutsideClick(contentRef, () => onClose());
+  useOutsideClick(contentRef, () => onClose(), showTrigger);
   useFocusTrap(contentRef, showTrigger);
   useEscapePress(() => onClose(), showTrigger);
 

--- a/src/components/header/header.scss
+++ b/src/components/header/header.scss
@@ -1,8 +1,7 @@
 @import '../../assets/colors';
 @import '../../assets/styles';
 
-$element-gap: 16px;
-$search-bar-offset: ($content-padding - $element-gap);
+$search-bar-offset: ($content-padding - $header-gap);
 
 .c-header {
   z-index: $z-header;
@@ -31,7 +30,7 @@ $search-bar-offset: ($content-padding - $element-gap);
     align-items: center;
     justify-content: space-between;
     height: 100%;
-    gap: $element-gap;
+    gap: $header-gap;
 
     .c-header-nav {
       @include hover-pointer;
@@ -60,7 +59,7 @@ $search-bar-offset: ($content-padding - $element-gap);
 
       @media screen and (max-width: $small-screen) {
         flex: 0;
-        padding-left: ($element-gap);
+        padding-left: ($header-gap);
       }
 
       a.c-header-anchor {
@@ -102,10 +101,10 @@ $search-bar-offset: ($content-padding - $element-gap);
       justify-content: flex-end;
       align-items: center;
       flex: 0 0 min(20vw, 100px);
-      padding-right: $element-gap * 2;
+      padding-right: $header-gap * 2;
 
       @media screen and (max-width: $small-screen) {
-        padding-right: $element-gap;
+        padding-right: $header-gap;
       }
 
       button {
@@ -116,8 +115,7 @@ $search-bar-offset: ($content-padding - $element-gap);
           background-color: transparent;
         }
 
-        &.sign-in-button,
-        &.logout-button {
+        &.sign-in-button {
           background-color: $electric-blue;
         }
       }

--- a/src/components/header/header.tsx
+++ b/src/components/header/header.tsx
@@ -2,11 +2,12 @@ import React from 'react';
 import { useNavigate } from 'react-router-dom';
 import { AnimatePresence, motion } from 'framer-motion';
 import { useRecoilState, useRecoilValue } from 'recoil';
+import { WelcomeUser } from './welcome-user/welcome-user';
 import { CancelIcon } from '../../assets/icons/cancel-icon/cancel-icon';
 import { HamburgerMenuIcon } from '../../assets/icons/hamburger-menu-icon/hamburger-menu-icon';
 import { useUserClient } from '../../hooks/api/use-user-client';
 import { paths } from '../../routing/paths';
-import { authJwtState } from '../../state/auth-jwt';
+import { authJwtState, isAuthJwt } from '../../state/auth-jwt';
 import { navToggledState } from '../../state/nav';
 import { userDecksSortedState } from '../../state/user-decks';
 import { Button } from '../button/button';
@@ -29,6 +30,7 @@ export const Header = ({
 }: HeaderProps) => {
   const authJwt = useRecoilValue(authJwtState);
   const decks = useRecoilValue(userDecksSortedState);
+
   const [navToggled, setNavToggled] = useRecoilState(navToggledState);
 
   const userClient = useUserClient();
@@ -91,12 +93,8 @@ export const Header = ({
   }
 
   function getAccountButtons() {
-    if (authJwt && authJwt.accessToken && authJwt.refreshToken) {
-      return (
-        <Button onClick={handleLogoutClick} className="logout-button">
-          logout
-        </Button>
-      );
+    if (isAuthJwt(authJwt)) {
+      return <WelcomeUser onProfileClick={handleProfileClick} onLogoutClick={handleLogoutClick} />;
     } else {
       return (
         <>
@@ -125,6 +123,10 @@ export const Header = ({
 
   function handleSignInClick() {
     navigate(paths.signIn, { replace: true }); // replace may be a mistake, we'll see
+  }
+
+  function handleProfileClick() {
+    navigate(paths.profile);
   }
 
   function handleLogoutClick() {

--- a/src/components/header/welcome-user/welcome-user.scss
+++ b/src/components/header/welcome-user/welcome-user.scss
@@ -1,0 +1,80 @@
+@import '../../../assets/colors';
+@import '../../../assets/styles';
+
+// popup styles
+.welcome-account-popup {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+
+  .c-welcome-presentable {
+    padding-bottom: 4px;
+
+    .greeting-text {
+      display: block;
+      color: $blue;
+    }
+  }
+
+  .profile-button,
+  .logout-button {
+    padding: 12px;
+    border: none;
+    background-color: $deck-cover-blue;
+    text-align: right;
+  }
+}
+
+// fallback styles
+.c-account-popup-fallback {
+  .logout-button {
+    padding: 12px;
+    border: none;
+    background-color: $electric-blue;
+  }
+}
+
+// normal styles
+.c-header-welcome-user {
+  // classes to apply when popup toggled
+  &.popup {
+    position: relative;
+
+    .presentable {
+      // not display none; we still want it to take up space
+      visibility: hidden;
+    }
+  }
+
+  .with-popup {
+    display: none;
+  }
+}
+
+// main presentation (name-image) for this component
+.c-welcome-presentable {
+  display: flex;
+  gap: 12px;
+  cursor: pointer;
+
+  .greeting-text {
+    color: $white;
+    font-weight: bold;
+    white-space: nowrap;
+    align-self: center;
+    padding-top: 2px;
+
+    max-width: max(150px, 20vw);
+    @include ellipsis-overflow;
+
+    @media screen and (max-width: $large-screen) {
+      display: none;
+    }
+  }
+
+  .profile-picture {
+    width: 35px;
+    height: 35px;
+    border-radius: 50%;
+  }
+}

--- a/src/components/header/welcome-user/welcome-user.scss
+++ b/src/components/header/welcome-user/welcome-user.scss
@@ -5,10 +5,9 @@
 .welcome-account-popup {
   display: flex;
   flex-direction: column;
-  gap: 4px;
 
   .c-welcome-presentable {
-    padding-bottom: 4px;
+    padding: 8px 16px;
 
     .greeting-text {
       display: block;
@@ -18,8 +17,10 @@
 
   .profile-button,
   .logout-button {
+    margin: 0px 2px 2px 2px;
     padding: 12px;
     border: none;
+    border-radius: $standard-radius / 2;
     background-color: $deck-cover-blue;
     text-align: right;
   }
@@ -28,6 +29,7 @@
 // fallback styles
 .c-account-popup-fallback {
   .logout-button {
+    @include hover($light-blue);
     padding: 12px;
     border: none;
     background-color: $electric-blue;

--- a/src/components/header/welcome-user/welcome-user.test.tsx
+++ b/src/components/header/welcome-user/welcome-user.test.tsx
@@ -1,0 +1,99 @@
+import React from 'react';
+import { prettyDOM, screen } from '@testing-library/react';
+import { act, renderHook } from '@testing-library/react-hooks';
+import userEvent from '@testing-library/user-event';
+import { enableFetchMocks } from 'jest-fetch-mock';
+import { MutableSnapshot } from 'recoil';
+import { WelcomeUser } from './welcome-user';
+import { renderWithTestRoots } from '../../../app.test';
+import { authJwtState, UserInfo, userInfoStateAsync } from '../../../state/auth-jwt';
+import { userDecksState } from '../../../state/user-decks';
+
+// provide fetchMock global and disable mocking initially
+enableFetchMocks();
+fetchMock.dontMock();
+
+describe('WelcomeUser', () => {
+  beforeEach(() => {
+    // setup portal element for modal to render on
+    document.body.innerHTML = `<div id="portal"></div>`;
+  });
+
+  afterEach(() => {
+    fetchMock.resetMocks();
+  });
+
+  it('should render correctly with default props', () => {
+    renderWithTestRoots(<WelcomeUser className="test-class-789" />);
+    expect(document.querySelectorAll('.test-class-789')).toHaveLength(1);
+  });
+
+  it('should render with fallback if user info state is empty', async () => {
+    renderWithTestRoots(<WelcomeUser />);
+    await flushMacrotasks();
+
+    // fallback is a 'log out' button
+    expect(screen.queryAllByText('hi, test1').length).toEqual(0);
+    expect(screen.queryAllByText('log out').length).toEqual(1);
+  });
+
+  it('should greet user if user info state is empty', async () => {
+    renderWithTestRoots(<WelcomeUser />, { recoilState: getInitRecoilState() });
+    await flushMacrotasks();
+
+    expect(screen.queryAllByText('hi, test1').length).not.toEqual(0);
+  });
+
+  it('should perform actions in account popup', async () => {
+    const mockButtonClick = jest.fn();
+    renderWithTestRoots(
+      <WelcomeUser onProfileClick={mockButtonClick} onLogoutClick={mockButtonClick} />,
+      { recoilState: getInitRecoilState() }
+    );
+    await flushMacrotasks();
+
+    // open account popup (not needed, but in case of any side effects)
+    const greetingElement = screen.queryAllByText('hi, test1')[0];
+    userEvent.click(greetingElement);
+    expect(mockButtonClick).toBeCalledTimes(0);
+
+    // click all buttons
+    const actionButtons = document.querySelectorAll('button');
+    actionButtons.forEach((button) => userEvent.click(button));
+    expect(mockButtonClick).toBeCalledTimes(2);
+  });
+
+  /**
+   * Provides a recoil state that setups the mocking of the `userInfoStateAsync` selector.
+   * Can optionally pass in the UserInfo to be mocked if desired.
+   */
+  function getInitRecoilState(userInfo?: UserInfo): (snapshot: MutableSnapshot) => void {
+    fetchMock.doMock();
+
+    // expected /users request from `userInfoState` selector --> to mocked response
+    fetchMock.mockResponse(
+      JSON.stringify(
+        userInfo ?? {
+          username: 'test1',
+          email: 'test1@test.com',
+        }
+      ),
+      { headers: { 'content-type': 'application/json' } }
+    );
+
+    // setting up this state causes the `userInfoState` selector to asynchronously update
+    return (snapshot: MutableSnapshot) => {
+      snapshot.set(authJwtState, { accessToken: 'test', refreshToken: 'test' });
+    };
+  }
+
+  async function flushMacrotasks() {
+    return act(
+      () =>
+        new Promise((resolve) => {
+          setTimeout(resolve, 100);
+          jest.runAllTimers();
+        })
+    );
+  }
+});

--- a/src/components/header/welcome-user/welcome-user.tsx
+++ b/src/components/header/welcome-user/welcome-user.tsx
@@ -1,0 +1,71 @@
+import React, { useState } from 'react';
+import { useRecoilValue } from 'recoil';
+import { useUserClient } from '../../../hooks/api/use-user-client';
+import { userInfoState } from '../../../state/auth-jwt';
+import { Button } from '../../button/button';
+import { AccountPopup } from '../account-popup/account-popup';
+import './welcome-user.scss';
+
+interface WelcomeUserProps {
+  className?: string;
+  onProfileClick?: (event: React.MouseEvent) => void;
+  onLogoutClick?: (event: React.MouseEvent) => void;
+}
+
+export const WelcomeUser = (props: WelcomeUserProps) => {
+  return (
+    <React.Suspense fallback={getFallback(props)}>
+      <AsyncWelcomeUser {...props} />
+    </React.Suspense>
+  );
+};
+
+const AsyncWelcomeUser = ({ className = '', onProfileClick, onLogoutClick }: WelcomeUserProps) => {
+  const userData = useRecoilValue(userInfoState);
+  const userClient = useUserClient();
+  const pfpUrl = userClient.getProfilePictureUrl(userData?.email ?? '');
+
+  const [showPopup, setShowPopup] = useState(false);
+  const popupClass = showPopup ? 'popup' : '';
+
+  return (
+    <div
+      className={`c-header-welcome-user ${popupClass} ${className}`}
+      onClick={() => setShowPopup((curr) => !curr)}
+    >
+      <div className="c-welcome-presentable">
+        <span className="greeting-text">{`hi, ${userData?.username}`}</span>
+        <img className="profile-picture" src={pfpUrl} loading="lazy" />
+      </div>
+
+      <AccountPopup
+        className={`welcome-account-popup ${className}`}
+        showTrigger={showPopup}
+        onClose={() => setShowPopup((curr) => !curr)}
+      >
+        <div className="c-welcome-presentable">
+          <span className="greeting-text">{`hi, ${userData?.username}`}</span>
+          <img className="profile-picture" src={pfpUrl} loading="lazy" />
+        </div>
+        <Button className="profile-button" onClick={(event) => onProfileClick?.(event)}>
+          my profile
+        </Button>
+        <Button className="logout-button" onClick={(event) => onLogoutClick?.(event)}>
+          log out
+        </Button>
+      </AccountPopup>
+    </div>
+  );
+};
+
+function getFallback(props: WelcomeUserProps) {
+  const { className = '', onLogoutClick } = props;
+
+  return (
+    <div className={`c-account-popup-fallback ${className}`}>
+      <Button className="logout-button" onClick={(event) => onLogoutClick?.(event)}>
+        log out
+      </Button>
+    </div>
+  );
+}

--- a/src/components/header/welcome-user/welcome-user.tsx
+++ b/src/components/header/welcome-user/welcome-user.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { useRecoilValue } from 'recoil';
 import { useUserClient } from '../../../hooks/api/use-user-client';
-import { userInfoState } from '../../../state/auth-jwt';
+import { userInfoStateAsync } from '../../../state/auth-jwt';
 import { Button } from '../../button/button';
 import { AccountPopup } from '../account-popup/account-popup';
 import './welcome-user.scss';
@@ -21,7 +21,7 @@ export const WelcomeUser = (props: WelcomeUserProps) => {
 };
 
 const AsyncWelcomeUser = ({ className = '', onProfileClick, onLogoutClick }: WelcomeUserProps) => {
-  const userData = useRecoilValue(userInfoState);
+  const userData = useRecoilValue(userInfoStateAsync);
   const userClient = useUserClient();
   const pfpUrl = userClient.getProfilePictureUrl(userData?.email ?? '');
 

--- a/src/components/header/welcome-user/welcome-user.tsx
+++ b/src/components/header/welcome-user/welcome-user.tsx
@@ -29,21 +29,19 @@ const AsyncWelcomeUser = ({ className = '', onProfileClick, onLogoutClick }: Wel
   const popupClass = showPopup ? 'popup' : '';
 
   return (
-    <div
-      className={`c-header-welcome-user ${popupClass} ${className}`}
-      onClick={() => setShowPopup((curr) => !curr)}
-    >
-      <div className="c-welcome-presentable">
-        <span className="greeting-text">{`hi, ${userData?.username}`}</span>
-        <img className="profile-picture" src={pfpUrl} loading="lazy" />
+    <>
+      <div className={`c-header-welcome-user ${popupClass} ${className}`}>
+        <div className="c-welcome-presentable" onClick={() => setShowPopup((curr) => !curr)}>
+          <span className="greeting-text">{`hi, ${userData?.username}`}</span>
+          <img className="profile-picture" src={pfpUrl} loading="lazy" />
+        </div>
       </div>
-
       <AccountPopup
         className={`welcome-account-popup ${className}`}
         showTrigger={showPopup}
-        onClose={() => setShowPopup((curr) => !curr)}
+        onClose={() => setShowPopup(false)}
       >
-        <div className="c-welcome-presentable">
+        <div className="c-welcome-presentable" onClick={() => setShowPopup((curr) => !curr)}>
           <span className="greeting-text">{`hi, ${userData?.username}`}</span>
           <img className="profile-picture" src={pfpUrl} loading="lazy" />
         </div>
@@ -54,7 +52,7 @@ const AsyncWelcomeUser = ({ className = '', onProfileClick, onLogoutClick }: Wel
           log out
         </Button>
       </AccountPopup>
-    </div>
+    </>
   );
 };
 

--- a/src/components/kebab-menu/kebab-menu.tsx
+++ b/src/components/kebab-menu/kebab-menu.tsx
@@ -1,7 +1,7 @@
 import React, { useRef, useState } from 'react';
 import { KebabMenuIcon } from '../../assets/icons/kebab-menu-icon/kebab-menu-icon';
-import { noop } from '../../helpers/func';
 import { useFocusTrap } from '../../hooks/use-focus-trap';
+import { useEscapePress } from '../../hooks/use-key-press';
 import { useOutsideClick } from '../../hooks/use-outside-click';
 import { Button } from '../button/button';
 import { DropDownOption, DropDownOptions } from '../drop-down-options/drop-down-options';
@@ -23,8 +23,9 @@ export const KebabMenu = <T extends React.ReactNode>({
   onOptionSelect,
 }: KebabMenuProps<T>) => {
   const kebabMenuRef = useRef(null);
-  useOutsideClick(kebabMenuRef, () => setIsOpen(false));
+  useOutsideClick(kebabMenuRef, () => setIsOpen(false), isOpen);
   useFocusTrap(kebabMenuRef, isOpen);
+  useEscapePress(() => setIsOpen(false), isOpen);
 
   return (
     <div className={`c-kebab-menu ${className}`} ref={kebabMenuRef}>

--- a/src/components/popup-modal/popup-modal.tsx
+++ b/src/components/popup-modal/popup-modal.tsx
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom';
 import { CancelIcon } from '../../assets/icons/cancel-icon/cancel-icon';
 import { useFocusFirst } from '../../hooks/use-focus-first';
 import { useFocusTrap } from '../../hooks/use-focus-trap';
+import { useEscapePress } from '../../hooks/use-key-press';
 import { useOutsideClick } from '../../hooks/use-outside-click';
 import './popup-modal.scss';
 
@@ -30,6 +31,8 @@ export const PopupModal = ({
 
   // accessibility: auto-focus the first focusable element (if any)
   useFocusFirst(contentRef, showTrigger);
+
+  useEscapePress(() => onClose(), showTrigger);
 
   // render onto <div id="portal"></div> instead of in parent hierarchy but still propagate events
   return ReactDOM.createPortal(

--- a/src/components/popup-modal/popup-modal.tsx
+++ b/src/components/popup-modal/popup-modal.tsx
@@ -24,14 +24,10 @@ export const PopupModal = ({
 }: PopupModalProps) => {
   // handle clicking outside modal if `outsideClickFiresOnClose` is enabled
   const contentRef = useRef<HTMLDivElement>(null);
-  useOutsideClick(contentRef, () => onClose(), outsideClickFiresOnClose);
 
-  // trap accessibility controls (i.e. tabbing) in the content
-  useFocusTrap(contentRef, showTrigger); // hook/unhook when showTrigger changes
-
-  // accessibility: auto-focus the first focusable element (if any)
-  useFocusFirst(contentRef, showTrigger);
-
+  useOutsideClick(contentRef, () => onClose(), showTrigger && outsideClickFiresOnClose);
+  useFocusTrap(contentRef, showTrigger); // trap accessibility controls (i.e. tabbing) in the content
+  useFocusFirst(contentRef, showTrigger); // accessibility: auto-focus the first focusable element (if any)
   useEscapePress(() => onClose(), showTrigger);
 
   // render onto <div id="portal"></div> instead of in parent hierarchy but still propagate events

--- a/src/components/search-bar/search-bar.tsx
+++ b/src/components/search-bar/search-bar.tsx
@@ -4,6 +4,7 @@ import { ReactComponent as SearchIcon } from '../../assets/svg/search-icon.svg';
 import { debounce, noop } from '../../helpers/func';
 import { includesIgnoreCase } from '../../helpers/string';
 import { useFocusTrap } from '../../hooks/use-focus-trap';
+import { useEscapePress } from '../../hooks/use-key-press';
 import { useOutsideClick } from '../../hooks/use-outside-click';
 import { Button } from '../button/button';
 import { DropDownOption, DropDownOptions } from '../drop-down-options/drop-down-options';
@@ -46,6 +47,7 @@ export const SearchBar = ({
   const wrapperDivRef = useRef(null);
   useOutsideClick(wrapperDivRef, () => setHasClickedSinceLastChange(true));
   useFocusTrap(wrapperDivRef, shouldShowDropDown());
+  useEscapePress(() => setHasClickedSinceLastChange(true), shouldShowDropDown());
 
   return (
     <div className="c-search-bar-wrapper" ref={wrapperDivRef}>

--- a/src/components/search-bar/search-bar.tsx
+++ b/src/components/search-bar/search-bar.tsx
@@ -45,7 +45,7 @@ export const SearchBar = ({
 
   // hide dropdown after clicking outside the search bar wrapper div
   const wrapperDivRef = useRef(null);
-  useOutsideClick(wrapperDivRef, () => setHasClickedSinceLastChange(true));
+  useOutsideClick(wrapperDivRef, () => setHasClickedSinceLastChange(true), shouldShowDropDown());
   useFocusTrap(wrapperDivRef, shouldShowDropDown());
   useEscapePress(() => setHasClickedSinceLastChange(true), shouldShowDropDown());
 

--- a/src/helpers/validator.ts
+++ b/src/helpers/validator.ts
@@ -2,6 +2,8 @@
  * Creates a user-type guard for objects provided a simple key-to-type schema.
  * Optional (?) types should not be provided in the simple schema.
  *
+ * For more complex validators, the `ajv` NPM package should be used.
+ *
  * @param schema - (e.g.) { 'message': 'string', 'id': 'number' }
  */
 export function objectSchemaSimple<T extends object>(schema: Record<string, string>) {
@@ -15,6 +17,14 @@ export function objectSchemaSimple<T extends object>(schema: Record<string, stri
       return value && typeof value === expectedType;
     });
   };
+}
+
+/**
+ * A safer alternative to checking if `subject` is defined (not undefined).
+ * This avoids dealing with the idiosyncrasies of truthy/falsy values.
+ */
+export function isDefined<T>(subject: T | undefined | null): subject is T {
+  return subject !== null && typeof subject !== 'undefined';
 }
 
 export function isObject(subject: unknown): subject is Record<string, unknown> {

--- a/src/hooks/api/use-fetch-wrapper.ts
+++ b/src/hooks/api/use-fetch-wrapper.ts
@@ -2,7 +2,7 @@ import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useSetRecoilState } from 'recoil';
 import { ECHOSTUDY_API_URL } from '../../helpers/api';
-import { objectSchemaSimple } from '../../helpers/validator';
+import { isDefined, objectSchemaSimple } from '../../helpers/validator';
 import { paths } from '../../routing/paths';
 import { AuthJwt, authJwtState, authJwtToJson, jsonToAuthJwt } from '../../state/auth-jwt';
 import { LocalStorageKeys } from '../../state/init';
@@ -76,7 +76,12 @@ export function useFetchWrapper(prependApiUrl?: string) {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
   ): Promise<any> {
     const maybeContentTypeHeader = body ? { 'Content-Type': 'application/json' } : undefined;
-    const resolvedUrl = (prependApiUrl ?? '') + url;
+
+    // only prepend if url is NOT an absolute url
+    let resolvedUrl = url;
+    if (!url.includes('://') && isDefined(prependApiUrl)) {
+      resolvedUrl = prependApiUrl + url;
+    }
 
     const response = await fetch(resolvedUrl, {
       method: method,
@@ -161,6 +166,8 @@ export function useFetchWrapper(prependApiUrl?: string) {
       return undefined;
     }
 
+    // NOTE: this needs to be updated to include more types as needed
+    // (e.g. image/jpeg, text/blob, etrc.)
     if (contentType?.startsWith('application/json')) {
       return JSON.parse(text);
     } else if (contentType?.startsWith('text/plain')) {

--- a/src/hooks/api/use-user-client.ts
+++ b/src/hooks/api/use-user-client.ts
@@ -151,9 +151,9 @@ export function useUserClient() {
   }
 
   function getProfilePictureUrl(email: string): string {
-    // if the email isn't linked with Gravatar, the `d=identicon` query param generates a random unique img
+    // if the email isn't linked with Gravatar, the `d=retro` query param generates a random unique 8-bit img
     // we do this to avoid displaying the default boring Gravatar icon; instead, a unique one to the email hash
     const emailHash = Md5.hashStr(email.trim().toLowerCase());
-    return `https://gravatar.com/avatar/${emailHash}?d=identicon`;
+    return `https://gravatar.com/avatar/${emailHash}?d=retro`;
   }
 }

--- a/src/hooks/tests/use-fetch-wrapper.test.ts
+++ b/src/hooks/tests/use-fetch-wrapper.test.ts
@@ -75,6 +75,20 @@ describe('useFetchWrapper', () => {
     await expect(fetchNext()).rejects.toThrow(); // invalid/invalid
   });
 
+  it('should override prepend url if the request contains an absolute url', async () => {
+    const fetchWrapper = setupFetchWrapper();
+
+    fetchMock.mockResponseOnce(JSON.stringify({ data: '12345' }), {
+      headers: { ...jsonContent },
+    });
+    //  https://test.test.noprependpls (which passes mock regex)
+    const absoluteUrl = TEST_DOMAIN + '.noprependpls';
+    await fetchWrapper.get(absoluteUrl);
+
+    // expect(fetchMock).toBeCalledWith(absoluteUrl);
+    expect(fetchMock.mock.calls[0][0]).toEqual(absoluteUrl);
+  });
+
   function setupFetchWrapper() {
     const { result } = renderHook(() => useFetchWrapper(TEST_DOMAIN), {
       wrapper: ({ children }) => withTestRoots(children),

--- a/src/hooks/use-key-press.ts
+++ b/src/hooks/use-key-press.ts
@@ -17,17 +17,17 @@ export const useKeyPress = (
   useEffect(() => {
     if (!active) return;
 
-    const handleEscapeKey = (event: KeyboardEvent) => {
+    const handleKeyPress = (event: KeyboardEvent) => {
       if (event.key === key) {
         action(event);
       }
     };
-    document.addEventListener('keydown', handleEscapeKey);
+    document.addEventListener('keydown', handleKeyPress);
 
     // destructor; called when component using this hook gets destroyed or a dependency changes
     return () => {
       if (!active) return;
-      document.removeEventListener('keydown', handleEscapeKey);
+      document.removeEventListener('keydown', handleKeyPress);
     };
   }, [key, action, active, ...extraDeps]);
 };

--- a/src/hooks/use-key-press.ts
+++ b/src/hooks/use-key-press.ts
@@ -1,0 +1,44 @@
+import { useEffect } from 'react';
+
+/**
+ * Perform an action (callback) whenever a key press occurs.
+ *
+ * @param key the key string pressed (e.g. 'Tab' or 'Escape')
+ * @param action callback handler after a click outside occurs
+ * @param active conditionally enable this hook (default: true [always enabled])
+ * @param extraDeps extra dependencies to rehook; do NOT include types in `active`
+ */
+export const useKeyPress = (
+  key: string,
+  action: (event: KeyboardEvent) => void,
+  active = true,
+  ...extraDeps: unknown[]
+): void => {
+  useEffect(() => {
+    if (!active) return;
+
+    const handleEscapeKey = (event: KeyboardEvent) => {
+      if (event.key === key) {
+        action(event);
+      }
+    };
+    document.addEventListener('keydown', handleEscapeKey);
+
+    // destructor; called when component using this hook gets destroyed or a dependency changes
+    return () => {
+      if (!active) return;
+      document.removeEventListener('keydown', handleEscapeKey);
+    };
+  }, [key, action, active, ...extraDeps]);
+};
+
+/**
+ * Convenience case for pressing the `Escape` key.
+ */
+export const useEscapePress = (
+  action: (event: KeyboardEvent) => void,
+  active = true,
+  ...extraDeps: unknown[]
+) => {
+  return useKeyPress('Escape', action, active, extraDeps);
+};

--- a/src/hooks/use-outside-click.ts
+++ b/src/hooks/use-outside-click.ts
@@ -22,9 +22,7 @@ export const useOutsideClick = (
         action(event);
       }
     };
-
     document.addEventListener('mousedown', handleOutsideClick);
-
     // destructor; called when component using this hook gets destroyed or a dependency changes
     return () => {
       if (!active) return;

--- a/src/pages/decks/flashcard-decks.scss
+++ b/src/pages/decks/flashcard-decks.scss
@@ -16,6 +16,10 @@
     justify-content: space-between;
     gap: 16px;
 
+    @media screen and (max-width: $small-screen) {
+      padding: 0px 12px; // to offset page margin shrinking
+    }
+
     > label {
       color: $white;
       font-size: 30px;

--- a/src/pages/decks/flashcard-decks.tsx
+++ b/src/pages/decks/flashcard-decks.tsx
@@ -84,12 +84,10 @@ export const FlashcardDecksPage = () => {
   }
 
   function onAddDeckClicked() {
-    // todo: maybe different route without any params (:deckId) since there is no 'deck' yet
     navigate(paths.createDeck);
   }
 
   async function fetchDecksAndRefresh() {
-    // todo: should get deck by user id in the future
     const fetchedDecks = await decksClient.getAllDecks();
     setUserDecks(fetchedDecks);
   }

--- a/src/routing/paths.ts
+++ b/src/routing/paths.ts
@@ -8,4 +8,5 @@ export const enum paths {
   search = '/search',
   signIn = '/sign-in',
   signUp = '/sign-up',
+  profile = '/profile',
 }

--- a/src/state/auth-jwt.ts
+++ b/src/state/auth-jwt.ts
@@ -27,8 +27,8 @@ export interface UserInfo {
   phoneNumber?: string;
 }
 
-export const userInfoState = selector<UserInfo | undefined>({
-  key: 'userInfoState',
+export const userInfoStateAsync = selector<UserInfo | undefined>({
+  key: 'userInfoStateAsync',
   get: async ({ get }) => {
     const authJwt = get(authJwtState);
 

--- a/src/state/auth-jwt.ts
+++ b/src/state/auth-jwt.ts
@@ -1,5 +1,11 @@
-import { atom } from 'recoil';
+import { atom, selector } from 'recoil';
+import { ECHOSTUDY_API_URL } from '../helpers/api';
 import { objectSchemaSimple } from '../helpers/validator';
+import { useFetchWrapper } from '../hooks/api/use-fetch-wrapper';
+
+///////////////
+/// AuthJwt ///
+///////////////
 
 export interface AuthJwt {
   accessToken: string;
@@ -9,6 +15,45 @@ export interface AuthJwt {
 export const authJwtState = atom<AuthJwt | undefined>({
   key: 'authJwtState',
   default: undefined,
+});
+
+////////////////
+/// UserInfo ///
+////////////////
+
+export interface UserInfo {
+  username: string;
+  email: string;
+  phoneNumber?: string;
+}
+
+export const userInfoState = selector<UserInfo | undefined>({
+  key: 'userInfoState',
+  get: async ({ get }) => {
+    const authJwt = get(authJwtState);
+
+    if (!isAuthJwt(authJwt)) {
+      return undefined;
+    }
+
+    // we unfortuantely cannot use `useFetchWrapper` since that adds hooks (breaks rule of hooks)
+    // either we replace this selector with effects in a nested component that updates this atom
+    // or we write a new fetcher to avoid using stateful hooks (which doesn't seem really possible)
+    try {
+      const response = await fetch(`${ECHOSTUDY_API_URL}/users`, {
+        method: 'GET',
+        headers: {
+          ...{ Authorization: `Bearer ${authJwt.accessToken}` },
+        },
+      });
+      const userInfo = await response.json();
+
+      return { ...userInfo, phoneNumber: userInfo.phoneNumber ?? undefined };
+    } catch (error) {
+      console.error('An error occurred while resolving userInfoState selector:', error);
+      return undefined;
+    }
+  },
 });
 
 ////////////////////////


### PR DESCRIPTION
## summary!
- adds the account popup
  - can close when outside click or escape press
- updates header to show responsive account group 
- account pfp from Gravatar (defaults to unique 8-bit icon like github if not registered)
- new recoil selector (userInfoState) that has a dependency on the authJwt atom
  - whenever the jwt updates, it asynchronously fetches the user info
  - this is why the `log out` button is seen for a second, it's the `React.Suspense` fallback state

---

https://user-images.githubusercontent.com/29434693/191907829-11321d98-2520-4c0b-af57-af6ca57a5e62.mp4

