### PR TITLE
fix: add promise lock to requests during token refresh

### DIFF
--- a/src/helpers/promise.ts
+++ b/src/helpers/promise.ts
@@ -1,0 +1,23 @@
+/**
+ * Creates a deferred promise.
+ * Use sparingly: https://github.com/petkaantonov/bluebird/wiki/Promise-anti-patterns#the-deferred-anti-pattern
+ * The advantage of this is the ability to resolve a promise outside of its Promise scope.
+ */
+export function deferredPromise<U = unknown>(): {
+  promise: Promise<U>;
+  resolve: (value?: U) => void;
+  reject: (reason?: unknown) => void;
+} {
+  const deferred: Record<string, unknown> = {};
+
+  deferred.promise = new Promise((resolve, reject) => {
+    deferred.resolve = resolve;
+    deferred.reject = reject;
+  });
+
+  return deferred as {
+    promise: Promise<U>;
+    resolve: (value?: U) => void;
+    reject: (reason?: unknown) => void;
+  };
+}


### PR DESCRIPTION
## note to self: rebase on main

fixes a race condition between multiple refresh requests.
if the access token is expired and 2+ authorized requests are made at nearly the same time, all of them would try to refresh.

only one request at most should be refreshing and other ones (which got a 401) should be waiting until it completes

### solution
- add a promise lock (mutex) to the refresh
- if another requests tries to refresh but one is happening already:
  - skip the refresh
  - retry the original request when the promise lock resolves (i.e. refresh finishes) 
