### PR TITLE
feat: update card scores when lesson is finished

### DIFF
--- a/src/components/header/header.tsx
+++ b/src/components/header/header.tsx
@@ -118,11 +118,11 @@ export const Header = ({
   }
 
   function handleSignUpClick() {
-    navigate(paths.signUp, { replace: true }); // replace may be a mistake, we'll see
+    navigate(paths.signUp);
   }
 
   function handleSignInClick() {
-    navigate(paths.signIn, { replace: true }); // replace may be a mistake, we'll see
+    navigate(paths.signIn);
   }
 
   function handleProfileClick() {

--- a/src/components/registration-panel/registration-panel.tsx
+++ b/src/components/registration-panel/registration-panel.tsx
@@ -34,7 +34,11 @@ export const RegistrationPanel = ({
         <div className="registration-form">
           <div>{formHeader}</div>
           {children}
-          <Button onClick={onSubmitClick} className="registration-button">
+          <Button
+            className="registration-button"
+            disabled={submitLabelLoading}
+            onClick={onSubmitClick}
+          >
             {getSubmitButtonToggle(submitLabel)}
           </Button>
         </div>

--- a/src/helpers/time.ts
+++ b/src/helpers/time.ts
@@ -21,6 +21,14 @@ export function dateToUtcMs(date: Date): number {
 }
 
 /**
+ * Some date strings omit the UTC offset.
+ * This adds the Zulu (Z) to imply the date string is in UTC (GMT +0000).
+ */
+export function asUtcDate(dateString: string): Date {
+  return new Date(`${dateString}Z`);
+}
+
+/**
  * @returns returns the date formatted as MM/DD/YYYY
  */
 export function getFormattedDate(date: Date) {

--- a/src/hooks/api/use-cards-client.ts
+++ b/src/hooks/api/use-cards-client.ts
@@ -1,5 +1,6 @@
 import { useFetchWrapper } from './use-fetch-wrapper';
 import { ECHOSTUDY_API_URL, ensureHttps } from '../../helpers/api';
+import { asUtcDate } from '../../helpers/time';
 import { Card, createNewCard } from '../../models/card';
 import { LazyAudio } from '../../models/lazy-audio';
 
@@ -147,9 +148,9 @@ function JsonToCard(obj: any): Card {
   const card = createNewCard();
   card.id = obj['id'];
   card.score = obj['score'];
-  card.dateCreated = new Date(obj['date_created']);
-  card.dateUpdated = new Date(obj['date_updated']);
-  card.dateTouched = new Date(obj['date_touched']);
+  card.dateCreated = asUtcDate(obj['date_created']);
+  card.dateUpdated = asUtcDate(obj['date_updated']);
+  card.dateTouched = asUtcDate(obj['date_touched']);
   card.front = {
     language: obj['flang'],
     text: obj['ftext'],

--- a/src/hooks/api/use-cards-client.ts
+++ b/src/hooks/api/use-cards-client.ts
@@ -93,10 +93,10 @@ export function useCardsClient() {
     return Promise.all(cards.map((card) => updateCardById(card)));
   }
 
-  // PATCH: /Cards/Touch={id}&{score}
+  // POST: /Cards/Study
   async function updateCardScoreById(id: number, score: number): Promise<void> {
-    // note: potentially might be POST in the future
-    throw new Error('Not implemented');
+    const requestBody = { id: id, score: score };
+    return fetchWrapper.post('/Cards/Study', requestBody);
   }
 
   /////////////////

--- a/src/hooks/api/use-decks-client.ts
+++ b/src/hooks/api/use-decks-client.ts
@@ -1,5 +1,6 @@
 import { useFetchWrapper } from './use-fetch-wrapper';
 import { ECHOSTUDY_API_URL } from '../../helpers/api';
+import { asUtcDate } from '../../helpers/time';
 import { Deck } from '../../models/deck';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
@@ -131,9 +132,9 @@ function JsonToDeck(obj: any): Deck {
       frontLang: obj['default_flang'],
       backLang: obj['default_blang'],
       ownerId: obj['ownerId'],
-      dateCreated: new Date(obj['date_created']),
-      dateUpdated: new Date(obj['date_updated']),
-      dateTouched: new Date(obj['date_touched']),
+      dateCreated: asUtcDate(obj['date_created']),
+      dateUpdated: asUtcDate(obj['date_updated']),
+      dateTouched: asUtcDate(obj['date_touched']),
     },
     cards: [],
   };

--- a/src/hooks/use-mounted-ref.ts
+++ b/src/hooks/use-mounted-ref.ts
@@ -1,0 +1,16 @@
+import { useEffect, useRef } from 'react';
+
+/**
+ * @returns a `MutableRefObject<boolean>` that returns whether the component is mounted or not
+ */
+export function useMountedRef() {
+  const mountedRef = useRef(true);
+
+  useEffect(() => {
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  return mountedRef;
+}

--- a/src/hooks/use-play-card-audio.ts
+++ b/src/hooks/use-play-card-audio.ts
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
+import { useMountedRef } from './use-mounted-ref';
 import { useCaptureSpeech } from './use-speech-recognition';
 import { useTimer } from './use-timer';
 import correctSound from '../assets/sounds/correct.wav';
@@ -16,6 +17,7 @@ export function usePlayCardAudio() {
   const [activeCardKey, setActiveCard] = useState<string>('');
   const [activeCardSide, setActiveCardSide] = useState<'front' | 'back'>('front');
 
+  const mountedRef = useMountedRef();
   useEffect(() => {
     return () => clearAudio();
   }, []);
@@ -125,6 +127,11 @@ export function usePlayCardAudio() {
   }
 
   function playCardAudio(audio: LazyAudio) {
+    // component was unmounted
+    if (!mountedRef.current) {
+      return Promise.reject(`The audio wasn't played because the audio player was unmounted.`);
+    }
+
     activeAudioRef.current = audio;
     return new Promise<void>((resolve, reject) => {
       audio.once('end', () => resolve());

--- a/src/hooks/use-play-lesson.ts
+++ b/src/hooks/use-play-lesson.ts
@@ -54,7 +54,7 @@ export function usePlayLesson({ deck, numCards }: UsePlayLessonSettings) {
   function skipCard() {
     clearAudio();
     const next = nextCard(currentCard, upcomingCards, completedCards);
-    if (!isPaused) {
+    if (!isPaused && next) {
       playCard(next.currentCard, next.upcomingCards, next.completedCards);
     }
   }
@@ -92,7 +92,7 @@ export function usePlayLesson({ deck, numCards }: UsePlayLessonSettings) {
     setCurrentCard(updatedCard);
     const next = nextCard(updatedCard, upcomingCards, completedCards);
 
-    playCard(next.currentCard, next.upcomingCards, next.completedCards);
+    next && playCard(next.currentCard, next.upcomingCards, next.completedCards);
   }
 
   function nextCard(
@@ -100,12 +100,17 @@ export function usePlayLesson({ deck, numCards }: UsePlayLessonSettings) {
     upcomingCards: LessonCard[],
     completedCards: LessonCard[]
   ) {
+    if (!upcomingCards[0] && completedCards.map((card) => card.key).includes(currentCard.key)) {
+      return false;
+    }
+
     const newCompletedCards = [currentCard, ...completedCards];
     const newCurrentCard: LessonCard = upcomingCards[0] ?? currentCard;
     const newUpcomingCards = upcomingCards.slice(1);
     setCurrentCard(newCurrentCard);
     setCompletedCards(newCompletedCards);
     setUpcomingCards(newUpcomingCards);
+
     return {
       currentCard: newCurrentCard,
       completedCards: newCompletedCards,

--- a/src/hooks/use-play-lesson.ts
+++ b/src/hooks/use-play-lesson.ts
@@ -1,5 +1,6 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { usePlayCardAudio } from './use-play-card-audio';
+import { useSpacedRepetition } from './use-spaced-repetition';
 import { Deck } from '../models/deck';
 import { createNewLessonCard, LessonCard } from '../models/lesson-card';
 
@@ -12,11 +13,14 @@ interface UsePlayLessonSettings {
 }
 
 export function usePlayLesson({ deck, numCards }: UsePlayLessonSettings) {
+  const spacedRepetition = useMemo(() => useSpacedRepetition(), []);
+
   const [firstCard, ...restCards] = getLessonCards(deck, numCards);
   const [currentCard, setCurrentCard] = useState<LessonCard>(firstCard);
   const [upcomingCards, setUpcomingCards] = useState(restCards);
   const [completedCards, setCompletedCards] = useState<LessonCard[]>([]);
   const [isPaused, setIsPaused] = useState(true);
+
   const {
     pauseAudio,
     resumeAudio,
@@ -130,13 +134,14 @@ export function usePlayLesson({ deck, numCards }: UsePlayLessonSettings) {
       upcomingCards: newUpcomingCards,
     };
   }
-}
 
-// TODO: Add Sorting and Filtering based in settings
-function getLessonCards(deck: Deck, numCards: number): LessonCard[] {
-  if (deck.cards.length < numCards) {
-    throw Error('deck not contain enough cards specified in the lesson');
+  // TODO: Add Sorting and Filtering based in settings
+  function getLessonCards(deck: Deck, numCards: number): LessonCard[] {
+    if (deck.cards.length < numCards) {
+      throw Error('deck not contain enough cards specified in the lesson');
+    }
+
+    const cards = spacedRepetition.gatherStudyCards(deck, numCards);
+    return cards.map((card) => createNewLessonCard(card, deck, 1));
   }
-  const cards = deck.cards.slice(0, numCards);
-  return cards.map((card) => createNewLessonCard(card, deck, 1));
 }

--- a/src/hooks/use-spaced-repetition.ts
+++ b/src/hooks/use-spaced-repetition.ts
@@ -21,8 +21,6 @@ import { Deck } from '../models/deck';
  *   --       2d       5d       1wk      2wk
  */
 export function useSpacedRepetition() {
-  // TODO: this is likely the file to expose methods to update card scores
-  // thus this hook is relatively small now, but we'll use the useCardClient in the future
   return { gatherStudyCards };
 
   /**
@@ -99,9 +97,11 @@ export const BoxStaleDays: Record<Box, number> = {
   BOX5: 14,
 };
 
+export const MAX_SCORE = Object.keys(BoxStaleDays).length - 1;
+
 export function scoreToBox(score: number): Box {
   // shouldn't really happen, but just as a fail-safe
-  if (score >= 5) {
+  if (score > MAX_SCORE) {
     return 'BOX5';
   }
 

--- a/src/hooks/use-spaced-repetition.ts
+++ b/src/hooks/use-spaced-repetition.ts
@@ -128,15 +128,12 @@ export function getDaysUntilStale(card: Card) {
     return 0;
   }
 
-  // TODO TODO TODO TODO TODO TODO TODO TODO TODO TODO TODO TODO TODO TODO TODO
-  // TODO TODO TODO TODO TODO
-  const dateNow = new Date(); // TODO: time needs to match timezone with server.
-  // TODO TODO TODO TODO TODO
-  // TODO TODO TODO TODO TODO TODO TODO TODO TODO TODO TODO TODO TODO TODO TODO
-
   const box = scoreToBox(card.score);
   const daysUntilPoolable = BoxStaleDays[box];
-  const daysLastStudied = daysBetween(dateNow, card.dateUpdated);
+
+  // relative time is fine since we save the JS dates are in UTC ms
+  const dateNow = new Date();
+  const daysLastStudied = daysBetween(dateNow, card.dateTouched);
   const daysUntilStale = daysUntilPoolable - daysLastStudied;
   return daysUntilStale;
 }

--- a/src/models/lazy-audio.ts
+++ b/src/models/lazy-audio.ts
@@ -30,9 +30,16 @@ export class LazyAudio extends Howl {
   // alternatively, we can set `html5: true` and `preload: 'metadata'`
   public async durationAsync(id?: number | undefined): Promise<number> {
     if (this.state() === 'unloaded') {
-      this.load();
-      return new Promise((resolve) => {
+      return new Promise((resolve, reject) => {
         this.once('load', () => resolve(super.duration(id)));
+        this.once('loaderror', () => {
+          console.error('Failed to load duration for audio file, defaulting to 0.0.');
+          reject(0.0);
+        });
+
+        // intentionally register handlers before loading!
+        // smaller files might load too fast...
+        this.load();
       });
     } else {
       return super.duration(id);

--- a/src/models/mock/card.mock.ts
+++ b/src/models/mock/card.mock.ts
@@ -8,29 +8,29 @@ import {
 } from './card-content.mock';
 import { Card, createNewCard } from '../card';
 
-export const getTestFoxCard = (score?: number, dateUpdated?: Date): Card => {
+export const getTestFoxCard = (score?: number, dateTouched?: Date): Card => {
   const testCard = createNewCard();
   testCard.front = getTestFoxFront();
   testCard.back = getTestFoxBack();
   testCard.score = score ?? 0;
-  testCard.dateUpdated = dateUpdated ?? testCard.dateUpdated;
+  testCard.dateTouched = dateTouched ?? testCard.dateTouched;
   return testCard;
 };
 
-export const getTestMouseCard = (score?: number, dateUpdated?: Date): Card => {
+export const getTestMouseCard = (score?: number, dateTouched?: Date): Card => {
   const testCard = createNewCard();
   testCard.front = getTestMouseFront();
   testCard.back = getTestMouseBack();
   testCard.score = score ?? 0;
-  testCard.dateUpdated = dateUpdated ?? testCard.dateUpdated;
+  testCard.dateTouched = dateTouched ?? testCard.dateTouched;
   return testCard;
 };
 
-export const getTestMonkeyCard = (score?: number, dateUpdated?: Date): Card => {
+export const getTestMonkeyCard = (score?: number, dateTouched?: Date): Card => {
   const testCard = createNewCard();
   testCard.front = getTestMonkeyFront();
   testCard.back = getTestMonkeyBack();
   testCard.score = score ?? 0;
-  testCard.dateUpdated = dateUpdated ?? testCard.dateUpdated;
+  testCard.dateTouched = dateTouched ?? testCard.dateTouched;
   return testCard;
 };

--- a/src/pages/study-page/study-lesson-page/study-lesson-page.tsx
+++ b/src/pages/study-page/study-lesson-page/study-lesson-page.tsx
@@ -160,6 +160,7 @@ export const StudyLessonPage = ({ deck, onLessonComplete }: StudyPageLessonProps
       const lessonCards = completedCards.reverse();
       const lessonTime = getElapsedTime();
       onLessonComplete(lessonCards, lessonTime);
+      pause(); // avoids lingering audio if manually clicked to completion
     }
   }
 

--- a/src/pages/study-page/study-lesson-page/study-lesson-page.tsx
+++ b/src/pages/study-page/study-lesson-page/study-lesson-page.tsx
@@ -22,7 +22,10 @@ interface StudyPageLessonProps {
 }
 
 export const StudyLessonPage = ({ deck, onLessonComplete }: StudyPageLessonProps) => {
-  const numCards = 4; // TODO: we will want to make this configurable or just pull in all past due cards
+  // TODO: we will want to make this configurable or just pull in all past due cards
+  // making this the min of (# of cards, 5) for demo purposes
+  const numCards = Math.min(deck.cards.length, 5);
+
   const isFirstRender = useIsFirstRender();
   const [isPaused, setIsPaused] = useState(true);
   const { startStopWatch, pauseStopWatch, getElapsedTime } = useStopWatch();

--- a/src/pages/study-page/study-results-page/study-results-page.scss
+++ b/src/pages/study-page/study-results-page/study-results-page.scss
@@ -31,6 +31,19 @@
     .study-results-page-nav-buttons {
       justify-content: flex-end;
       gap: 20px;
+
+      .finish-lesson-content-container {
+        @include flex-center;
+        width: 100px;
+        height: 20px;
+
+        .finish-lesson-loading {
+          @include flex-center;
+          label {
+            padding-left: 8px;
+          }
+        }
+      }
     }
 
     @media screen and (max-width: $large-screen) {

--- a/src/pages/study-page/study-results-page/study-results-page.tsx
+++ b/src/pages/study-page/study-results-page/study-results-page.tsx
@@ -1,12 +1,15 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { StudyResultCards } from './study-result-cards/study-result-cards';
+import { UpToggle } from '../../../animations/up-toggle';
 import { CardStackIcon } from '../../../assets/icons/card-stack-icon/card-stack-icon';
 import { ClockIcon } from '../../../assets/icons/clock-icon/clock-icon';
+import { LoadingIcon } from '../../../assets/icons/loading-icon/loading-icon';
 import { StarIcon } from '../../../assets/icons/star-con/star-icon';
 import { BubbleDivider } from '../../../components/bubble-divider/bubble-divider';
 import { Button } from '../../../components/button/button';
 import { getFormattedMilliseconds } from '../../../helpers/time';
+import { usePrompt } from '../../../hooks/use-prompt';
 import { Deck } from '../../../models/deck';
 import { LessonCard } from '../../../models/lesson-card';
 import { paths } from '../../../routing/paths';
@@ -26,6 +29,16 @@ export const StudyResultsPage = ({
   onLessonCardsChange,
 }: StudyResultsPageProps) => {
   const navigate = useNavigate();
+
+  // block navigation if finish isn't clicked; otherwise, redirect back to the deck
+  const [areResultsApplied, setAreResultsApplied] = useState(false); // all done?
+  const [isUpdating, setIsUpdating] = useState(false); // currently sending update request?
+  usePrompt('Are you sure you want to discard the results of this lesson?', !areResultsApplied);
+  useEffect(() => {
+    if (areResultsApplied) {
+      navigate(`${paths.deck}/${deck.metaData.id}`);
+    }
+  }, [areResultsApplied]);
 
   const title = `${deck.metaData.title} Lesson Results`;
 
@@ -54,8 +67,18 @@ export const StudyResultsPage = ({
         <Button size="medium" onClick={() => navigate(`${paths.study}/${deck.metaData.id}`)}>
           study again
         </Button>
-        <Button size="medium" onClick={() => navigate(`${paths.deck}/${deck.metaData.id}`)}>
-          view deck
+        <Button size="medium" disabled={isUpdating} onClick={_handleFinishClick}>
+          <UpToggle
+            className="finish-lesson-content-container"
+            showDefault={!isUpdating}
+            defaultContent="finish lesson"
+            alternateContent={
+              <div className="finish-lesson-loading">
+                <LoadingIcon />
+                <label>finishing...</label>
+              </div>
+            }
+          />
         </Button>
       </div>
     );
@@ -91,5 +114,21 @@ export const StudyResultsPage = ({
         </div>
       </>
     );
+  }
+
+  async function _handleFinishClick() {
+    if (isUpdating) {
+      return;
+    }
+
+    setIsUpdating(true);
+
+    // TODO: send request
+    await new Promise((resolve) => setTimeout(resolve, 2000));
+
+    setIsUpdating(false);
+
+    // navigation is handled with a side effect on `areResultsApplied`
+    setAreResultsApplied(true);
   }
 };

--- a/src/state/auth-jwt.ts
+++ b/src/state/auth-jwt.ts
@@ -35,7 +35,7 @@ export const userInfoStateAsync = selector<UserInfo | undefined>({
       return undefined;
     }
 
-    // we unfortuantely cannot use `useFetchWrapper` since that adds hooks (breaks rule of hooks)
+    // we unfortunately cannot use `useFetchWrapper` since that adds hooks (breaks rule of hooks)
     // either we replace this selector with effects in a nested component that updates this atom
     // or we write a new fetcher to avoid using stateful hooks (which doesn't seem really possible)
     try {

--- a/src/state/user-decks.ts
+++ b/src/state/user-decks.ts
@@ -13,13 +13,13 @@ export const AllSortRules = [
 export type SortRules = typeof AllSortRules;
 export type SortRule = SortRules[number];
 
-// mutatable: raw user decks
+// mutable: raw user decks
 export const userDecksState = atom<Deck[]>({
   key: 'userDecksState',
   default: [],
 });
 
-// mutatable: sort order
+// mutable: sort order
 export const userDecksSortRuleState = atom<SortRule>({
   key: 'userDecksSortRuleState',
   default: 'last created',


### PR DESCRIPTION
## studying
- utilize spaced repetition when picking cards
- lesson size updated to be minimum of cards or 5 -- temporary until lesson config
- scores are updated when the `lesson finished` button is clicked
- **[bug fix]** you can no longer skip more than there are cards available
- **[bug fix]** stop lingering audio when lesson finishes by skipping or when clicking browser tab back button

## misc
- clicking on registration buttons in the header no longer resets the tab's history stack 
- dates from the server are serialized as UTC time (with assumption that server's time-zone stays UTC)
-  **[bug fix]** ensure listeners are registered before `audio.load()` is called
    - resolves an issue where audio doesn't play if the audio file was too small
    - to be specific, `durationAsync()` was never resolving since it loaded before the listener was registered