### PR TITLE
refactor: use path aliases for parent imports

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -7,6 +7,7 @@
     "extends": [
         "plugin:react/recommended",
         "plugin:@typescript-eslint/recommended",
+        "plugin:@dword-design/import-alias/recommended",
         "prettier"
     ],
     "parser": "@typescript-eslint/parser",
@@ -23,6 +24,14 @@
     ],
     "rules": {
         "import/no-duplicates": ["error"],
+        "@dword-design/import-alias/prefer-alias": [
+            "error",
+            {
+              "alias": {
+                "@": "./src/"
+              }
+            }
+        ],
         "simple-import-sort/imports": ["error", {
             "groups": [
               [

--- a/craco.config.ts
+++ b/craco.config.ts
@@ -5,7 +5,13 @@
 // https://github.com/gsoft-inc/craco/blob/master/packages/craco/README.md#configuration-file
 
 const CracoEsbuildPlugin = require('craco-esbuild');
+const path = require('path');
 
 export default () => ({
+  webpack: {
+    alias: {
+      '@': path.resolve(__dirname, 'src'),
+    },
+  },
   plugins: [{ plugin: CracoEsbuildPlugin, options: { skipEsbuildJest: true } }],
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
       },
       "devDependencies": {
         "@craco/craco": "^7.0.0-alpha.7",
+        "@dword-design/eslint-plugin-import-alias": "^2.0.7",
         "@testing-library/react": "^12.1.3",
         "@testing-library/react-hooks": "^8.0.1",
         "@types/dom-speech-recognition": "^0.0.1",
@@ -2073,6 +2074,61 @@
       },
       "peerDependencies": {
         "postcss": "^8.3"
+      }
+    },
+    "node_modules/@dword-design/dedent": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@dword-design/dedent/-/dedent-0.7.0.tgz",
+      "integrity": "sha512-OFmAmzKiDUh9m7WRMYcoEOPI7b5tS5hdqQmtKDwF+ZssVJv8a+GHo9VOtFsmlw3h8Roh/9QzFWIsjSFZyQUMdg==",
+      "dev": true,
+      "dependencies": {
+        "babel-plugin-add-module-exports": "^1.0.2"
+      }
+    },
+    "node_modules/@dword-design/endent": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@dword-design/endent/-/endent-1.4.1.tgz",
+      "integrity": "sha512-e2sCTzth5kyRdM0o+yEb5wBVzUdJL8Y6HblRGRV0Bif0knf1ZjRLhUjdCrqM+Muirb68X/xJzgdRDJVmLqgXGA==",
+      "dev": true,
+      "dependencies": {
+        "@dword-design/dedent": "^0.7.0",
+        "fast-json-parse": "^1.0.3",
+        "objectorarray": "^1.0.3"
+      }
+    },
+    "node_modules/@dword-design/eslint-plugin-import-alias": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@dword-design/eslint-plugin-import-alias/-/eslint-plugin-import-alias-2.0.7.tgz",
+      "integrity": "sha512-wJ0FjIjeAIpbRphDMPA9alDHrmxIfABNa9BEPfZxZRh2tS2oEjBWduHriMqcK9r9uACIKpZDpGwr4PEw97Pkaw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/core": "^7.10.2",
+        "@dword-design/functions": "^4.0.0",
+        "babel-plugin-module-resolver": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/dword-design"
+      }
+    },
+    "node_modules/@dword-design/functions": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@dword-design/functions/-/functions-4.1.0.tgz",
+      "integrity": "sha512-rPNYH6mADaPMFRoROaHSvnFWExacY7t9oq45Jw++37mqsQay0IX4aHqfAsmWbJPU/wyx1LkqKvNI+mizzpjpYA==",
+      "dev": true,
+      "dependencies": {
+        "@dword-design/endent": "^1.0.0",
+        "delay": "^5.0.0",
+        "lodash": "^4.17.15",
+        "tinycolor2": "^1.4.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/dword-design"
       }
     },
     "node_modules/@emotion/is-prop-valid": {
@@ -4884,6 +4940,12 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/babel-plugin-add-module-exports": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/babel-plugin-add-module-exports/-/babel-plugin-add-module-exports-1.0.4.tgz",
+      "integrity": "sha512-g+8yxHUZ60RcyaUpfNzy56OtWW+x9cyEe9j+CranqLiqbju2yf/Cy6ZtYK40EZxtrdHllzlVZgLmcOUCTlJ7Jg==",
+      "dev": true
+    },
     "node_modules/babel-plugin-dynamic-import-node": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.3.tgz",
@@ -4933,6 +4995,22 @@
       "engines": {
         "node": ">=10",
         "npm": ">=6"
+      }
+    },
+    "node_modules/babel-plugin-module-resolver": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-module-resolver/-/babel-plugin-module-resolver-4.1.0.tgz",
+      "integrity": "sha512-MlX10UDheRr3lb3P0WcaIdtCSRlxdQsB1sBqL7W0raF070bGl1HQQq5K3T2vf2XAYie+ww+5AKC/WrkjRO2knA==",
+      "dev": true,
+      "dependencies": {
+        "find-babel-config": "^1.2.0",
+        "glob": "^7.1.6",
+        "pkg-up": "^3.1.0",
+        "reselect": "^4.0.0",
+        "resolve": "^1.13.1"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
       }
     },
     "node_modules/babel-plugin-named-asset-import": {
@@ -6492,6 +6570,18 @@
         "rimraf": "^3.0.2",
         "slash": "^3.0.0"
       },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/delay": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/delay/-/delay-5.0.0.tgz",
+      "integrity": "sha512-ReEBKkIfe4ya47wlPYf/gu5ib6yUG0/Aez0JQZQz94kiWtRQvZIQbTiehsnwHvLSWJnQdhVeqYue7Id1dKr0qw==",
+      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -8764,6 +8854,12 @@
         "node": ">= 6"
       }
     },
+    "node_modules/fast-json-parse": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/fast-json-parse/-/fast-json-parse-1.0.3.tgz",
+      "integrity": "sha512-FRWsaZRWEJ1ESVNbDWmsAlqDk96gPQezzLghafp5J4GUKjbCz3OkAHuZs5TuPEtkbVQERysLp9xv6c24fBm8Aw==",
+      "dev": true
+    },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -8887,6 +8983,37 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "node_modules/find-babel-config": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/find-babel-config/-/find-babel-config-1.2.0.tgz",
+      "integrity": "sha512-jB2CHJeqy6a820ssiqwrKMeyC6nNdmrcgkKWJWmpoxpE8RKciYJXCcXRq1h2AzCo5I5BJeN2tkGEO3hLTuePRA==",
+      "dev": true,
+      "dependencies": {
+        "json5": "^0.5.1",
+        "path-exists": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/find-babel-config/node_modules/json5": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+      "integrity": "sha512-4xrs1aW+6N5DalkqSVA8fxh458CXvR99WU8WLKmq4v8eWAL86Xo3BVqyd3SkA9wEVjCMqyvvRRkshAdOnBp5rw==",
+      "dev": true,
+      "bin": {
+        "json5": "lib/cli.js"
+      }
+    },
+    "node_modules/find-babel-config/node_modules/path-exists": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+      "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/find-cache-dir": {
       "version": "3.3.2",
@@ -13277,6 +13404,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/objectorarray": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/objectorarray/-/objectorarray-1.0.5.tgz",
+      "integrity": "sha512-eJJDYkhJFFbBBAxeh8xW+weHlkI28n2ZdQV/J/DNfWfSKlGEf2xcfAbZTv3riEXHAhL9SVOTs2pRmXiSTf78xg==",
+      "dev": true
+    },
     "node_modules/obuf": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz",
@@ -15901,6 +16034,12 @@
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
     },
+    "node_modules/reselect": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.1.6.tgz",
+      "integrity": "sha512-ZovIuXqto7elwnxyXbBtCPo9YFEr3uJqj2rRbcOOog1bmu2Ag85M4hixSwFWyaBMKXNgvPaJ9OSu9SkBPIeJHQ==",
+      "dev": true
+    },
     "node_modules/resolve": {
       "version": "1.22.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.0.tgz",
@@ -17891,6 +18030,15 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/timsort/-/timsort-0.3.0.tgz",
       "integrity": "sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q="
+    },
+    "node_modules/tinycolor2": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.4.2.tgz",
+      "integrity": "sha512-vJhccZPs965sV/L2sU4oRQVAos0pQXwsvTLkWYdqJ+a8Q5kPFzJTuOFwy7UniPli44NKQGAglksjvOcpo95aZA==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/tmpl": {
       "version": "1.0.5",
@@ -20712,6 +20860,49 @@
         "postcss-value-parser": "^4.2.0"
       }
     },
+    "@dword-design/dedent": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@dword-design/dedent/-/dedent-0.7.0.tgz",
+      "integrity": "sha512-OFmAmzKiDUh9m7WRMYcoEOPI7b5tS5hdqQmtKDwF+ZssVJv8a+GHo9VOtFsmlw3h8Roh/9QzFWIsjSFZyQUMdg==",
+      "dev": true,
+      "requires": {
+        "babel-plugin-add-module-exports": "^1.0.2"
+      }
+    },
+    "@dword-design/endent": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@dword-design/endent/-/endent-1.4.1.tgz",
+      "integrity": "sha512-e2sCTzth5kyRdM0o+yEb5wBVzUdJL8Y6HblRGRV0Bif0knf1ZjRLhUjdCrqM+Muirb68X/xJzgdRDJVmLqgXGA==",
+      "dev": true,
+      "requires": {
+        "@dword-design/dedent": "^0.7.0",
+        "fast-json-parse": "^1.0.3",
+        "objectorarray": "^1.0.3"
+      }
+    },
+    "@dword-design/eslint-plugin-import-alias": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@dword-design/eslint-plugin-import-alias/-/eslint-plugin-import-alias-2.0.7.tgz",
+      "integrity": "sha512-wJ0FjIjeAIpbRphDMPA9alDHrmxIfABNa9BEPfZxZRh2tS2oEjBWduHriMqcK9r9uACIKpZDpGwr4PEw97Pkaw==",
+      "dev": true,
+      "requires": {
+        "@babel/core": "^7.10.2",
+        "@dword-design/functions": "^4.0.0",
+        "babel-plugin-module-resolver": "^4.0.0"
+      }
+    },
+    "@dword-design/functions": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@dword-design/functions/-/functions-4.1.0.tgz",
+      "integrity": "sha512-rPNYH6mADaPMFRoROaHSvnFWExacY7t9oq45Jw++37mqsQay0IX4aHqfAsmWbJPU/wyx1LkqKvNI+mizzpjpYA==",
+      "dev": true,
+      "requires": {
+        "@dword-design/endent": "^1.0.0",
+        "delay": "^5.0.0",
+        "lodash": "^4.17.15",
+        "tinycolor2": "^1.4.1"
+      }
+    },
     "@emotion/is-prop-valid": {
       "version": "0.8.8",
       "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz",
@@ -22768,6 +22959,12 @@
         }
       }
     },
+    "babel-plugin-add-module-exports": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/babel-plugin-add-module-exports/-/babel-plugin-add-module-exports-1.0.4.tgz",
+      "integrity": "sha512-g+8yxHUZ60RcyaUpfNzy56OtWW+x9cyEe9j+CranqLiqbju2yf/Cy6ZtYK40EZxtrdHllzlVZgLmcOUCTlJ7Jg==",
+      "dev": true
+    },
     "babel-plugin-dynamic-import-node": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.3.tgz",
@@ -22807,6 +23004,19 @@
         "@babel/runtime": "^7.12.5",
         "cosmiconfig": "^7.0.0",
         "resolve": "^1.19.0"
+      }
+    },
+    "babel-plugin-module-resolver": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-module-resolver/-/babel-plugin-module-resolver-4.1.0.tgz",
+      "integrity": "sha512-MlX10UDheRr3lb3P0WcaIdtCSRlxdQsB1sBqL7W0raF070bGl1HQQq5K3T2vf2XAYie+ww+5AKC/WrkjRO2knA==",
+      "dev": true,
+      "requires": {
+        "find-babel-config": "^1.2.0",
+        "glob": "^7.1.6",
+        "pkg-up": "^3.1.0",
+        "reselect": "^4.0.0",
+        "resolve": "^1.13.1"
       }
     },
     "babel-plugin-named-asset-import": {
@@ -23978,6 +24188,12 @@
         "rimraf": "^3.0.2",
         "slash": "^3.0.0"
       }
+    },
+    "delay": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/delay/-/delay-5.0.0.tgz",
+      "integrity": "sha512-ReEBKkIfe4ya47wlPYf/gu5ib6yUG0/Aez0JQZQz94kiWtRQvZIQbTiehsnwHvLSWJnQdhVeqYue7Id1dKr0qw==",
+      "dev": true
     },
     "delayed-stream": {
       "version": "1.0.0",
@@ -25598,6 +25814,12 @@
         }
       }
     },
+    "fast-json-parse": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/fast-json-parse/-/fast-json-parse-1.0.3.tgz",
+      "integrity": "sha512-FRWsaZRWEJ1ESVNbDWmsAlqDk96gPQezzLghafp5J4GUKjbCz3OkAHuZs5TuPEtkbVQERysLp9xv6c24fBm8Aw==",
+      "dev": true
+    },
     "fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -25696,6 +25918,30 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
+      }
+    },
+    "find-babel-config": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/find-babel-config/-/find-babel-config-1.2.0.tgz",
+      "integrity": "sha512-jB2CHJeqy6a820ssiqwrKMeyC6nNdmrcgkKWJWmpoxpE8RKciYJXCcXRq1h2AzCo5I5BJeN2tkGEO3hLTuePRA==",
+      "dev": true,
+      "requires": {
+        "json5": "^0.5.1",
+        "path-exists": "^3.0.0"
+      },
+      "dependencies": {
+        "json5": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+          "integrity": "sha512-4xrs1aW+6N5DalkqSVA8fxh458CXvR99WU8WLKmq4v8eWAL86Xo3BVqyd3SkA9wEVjCMqyvvRRkshAdOnBp5rw==",
+          "dev": true
+        },
+        "path-exists": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+          "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
+          "dev": true
         }
       }
     },
@@ -28893,6 +29139,12 @@
         "es-abstract": "^1.19.1"
       }
     },
+    "objectorarray": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/objectorarray/-/objectorarray-1.0.5.tgz",
+      "integrity": "sha512-eJJDYkhJFFbBBAxeh8xW+weHlkI28n2ZdQV/J/DNfWfSKlGEf2xcfAbZTv3riEXHAhL9SVOTs2pRmXiSTf78xg==",
+      "dev": true
+    },
     "obuf": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz",
@@ -30668,6 +30920,12 @@
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
     },
+    "reselect": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.1.6.tgz",
+      "integrity": "sha512-ZovIuXqto7elwnxyXbBtCPo9YFEr3uJqj2rRbcOOog1bmu2Ag85M4hixSwFWyaBMKXNgvPaJ9OSu9SkBPIeJHQ==",
+      "dev": true
+    },
     "resolve": {
       "version": "1.22.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.0.tgz",
@@ -32174,6 +32432,12 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/timsort/-/timsort-0.3.0.tgz",
       "integrity": "sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q="
+    },
+    "tinycolor2": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.4.2.tgz",
+      "integrity": "sha512-vJhccZPs965sV/L2sU4oRQVAos0pQXwsvTLkWYdqJ+a8Q5kPFzJTuOFwy7UniPli44NKQGAglksjvOcpo95aZA==",
+      "dev": true
     },
     "tmpl": {
       "version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,11 @@
       "react-app/jest"
     ]
   },
+  "jest": {
+    "moduleNameMapper": {
+      "^@/(.*)$": "<rootDir>/src/$1"
+    }
+  },
   "browserslist": {
     "production": [
       ">0.2%",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
   },
   "devDependencies": {
     "@craco/craco": "^7.0.0-alpha.7",
+    "@dword-design/eslint-plugin-import-alias": "^2.0.7",
     "@testing-library/react": "^12.1.3",
     "@testing-library/react-hooks": "^8.0.1",
     "@types/dom-speech-recognition": "^0.0.1",

--- a/src/animations/up-toggle.tsx
+++ b/src/animations/up-toggle.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { motion } from 'framer-motion';
-import { useIsFirstRender } from '../hooks/use-is-first-render';
+import { useIsFirstRender } from '@/hooks/use-is-first-render';
 
 interface UpToggleProps {
   className?: string;

--- a/src/app.scss
+++ b/src/app.scss
@@ -1,5 +1,5 @@
-@import './assets/colors';
-@import './assets/styles';
+@import '@/assets/colors';
+@import '@/assets/styles';
 
 :root {
   background-color: $black;

--- a/src/assets/icons/arrow-icon/arrow-icon.scss
+++ b/src/assets/icons/arrow-icon/arrow-icon.scss
@@ -1,4 +1,4 @@
-@import '../../colors';
+@import '@/assets/colors';
 
 $arrow-height: 14px;
 

--- a/src/assets/icons/arrow-icon/arrow-icon.tsx
+++ b/src/assets/icons/arrow-icon/arrow-icon.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ReactComponent as DownArrow } from '../../svg/down-arrow.svg';
+import { ReactComponent as DownArrow } from '@/assets/svg/down-arrow.svg';
 import './arrow-icon.scss';
 
 interface ArrowProps {

--- a/src/assets/icons/back-arrow-icon/back-arrow-icon.scss
+++ b/src/assets/icons/back-arrow-icon/back-arrow-icon.scss
@@ -1,5 +1,5 @@
-@import '../../colors';
-@import '../../styles';
+@import '@/assets/colors';
+@import '@/assets/styles';
 
 .back-arrow-icon {
   @include standard-transition;

--- a/src/assets/icons/back-arrow-icon/back-arrow-icon.tsx
+++ b/src/assets/icons/back-arrow-icon/back-arrow-icon.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ReactComponent as BackArrowSvg } from '../../svg/back-arrow.svg';
+import { ReactComponent as BackArrowSvg } from '@/assets/svg/back-arrow.svg';
 import './back-arrow-icon.scss';
 
 interface BackArrowIconProps {

--- a/src/assets/icons/cancel-icon/cancel-icon.scss
+++ b/src/assets/icons/cancel-icon/cancel-icon.scss
@@ -1,5 +1,5 @@
-@import '../../colors';
-@import '../../styles';
+@import '@/assets/colors';
+@import '@/assets/styles';
 
 svg.cancel-icon {
   @include standard-transition;

--- a/src/assets/icons/cancel-icon/cancel-icon.tsx
+++ b/src/assets/icons/cancel-icon/cancel-icon.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { noop } from '../../../helpers/func';
-import { ReactComponent as CancelIconSvg } from '../../svg/cancel-icon.svg';
+import { ReactComponent as CancelIconSvg } from '@/assets/svg/cancel-icon.svg';
+import { noop } from '@/helpers/func';
 import './cancel-icon.scss';
 
 interface CancelIconProps {

--- a/src/assets/icons/card-stack-icon/card-stack-icon.scss
+++ b/src/assets/icons/card-stack-icon/card-stack-icon.scss
@@ -1,1 +1,1 @@
-@import '../../colors';
+@import '@/assets/colors';

--- a/src/assets/icons/card-stack-icon/card-stack-icon.tsx
+++ b/src/assets/icons/card-stack-icon/card-stack-icon.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ReactComponent as CardStackSvg } from '../../svg/card-stack.svg';
+import { ReactComponent as CardStackSvg } from '@/assets/svg/card-stack.svg';
 import './card-stack-icon.scss';
 
 interface CardStackIconProps {

--- a/src/assets/icons/clock-icon/clock-icon.scss
+++ b/src/assets/icons/clock-icon/clock-icon.scss
@@ -1,1 +1,1 @@
-@import '../../colors';
+@import '@/assets/colors';

--- a/src/assets/icons/clock-icon/clock-icon.tsx
+++ b/src/assets/icons/clock-icon/clock-icon.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ReactComponent as ClockSvg } from '../../svg/clock.svg';
+import { ReactComponent as ClockSvg } from '@/assets/svg/clock.svg';
 import './clock-icon.scss';
 
 interface ClockIconProps {

--- a/src/assets/icons/copy-icon/copy-icon.scss
+++ b/src/assets/icons/copy-icon/copy-icon.scss
@@ -1,1 +1,1 @@
-@import '../../colors';
+@import '@/assets/colors';

--- a/src/assets/icons/copy-icon/copy-icon.tsx
+++ b/src/assets/icons/copy-icon/copy-icon.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ReactComponent as CopySvg } from '../../svg/copy.svg';
+import { ReactComponent as CopySvg } from '@/assets/svg/copy.svg';
 import './copy-icon.scss';
 
 interface CopyIconProps {

--- a/src/assets/icons/correct-icon/correct-icon.scss
+++ b/src/assets/icons/correct-icon/correct-icon.scss
@@ -1,1 +1,1 @@
-@import '../../colors';
+@import '@/assets/colors';

--- a/src/assets/icons/correct-icon/correct-icon.tsx
+++ b/src/assets/icons/correct-icon/correct-icon.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ReactComponent as CorrectSvg } from '../../svg/correct.svg';
+import { ReactComponent as CorrectSvg } from '@/assets/svg/correct.svg';
 import './correct-icon.scss';
 
 interface CorrectIconProps {

--- a/src/assets/icons/doc-icon/doc-icon.scss
+++ b/src/assets/icons/doc-icon/doc-icon.scss
@@ -1,5 +1,5 @@
-@import '../../colors';
-@import '../../styles';
+@import '@/assets/colors';
+@import '@/assets/styles';
 
 svg.doc-icon {
   @include standard-transition;

--- a/src/assets/icons/doc-icon/doc-icon.tsx
+++ b/src/assets/icons/doc-icon/doc-icon.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ReactComponent as DocSvg } from '../../svg/doc.svg';
+import { ReactComponent as DocSvg } from '@/assets/svg/doc.svg';
 import './doc-icon.scss';
 
 interface DocIconProps {

--- a/src/assets/icons/flashcard-arrow-icon/flashcard-arrow-icon.scss
+++ b/src/assets/icons/flashcard-arrow-icon/flashcard-arrow-icon.scss
@@ -1,5 +1,5 @@
-@import '../../colors';
-@import '../../styles';
+@import '@/assets/colors';
+@import '@/assets/styles';
 
 svg.flashcard-arrow-icon {
   @include standard-transition;

--- a/src/assets/icons/flashcard-arrow-icon/flashcard-arrow-icon.tsx
+++ b/src/assets/icons/flashcard-arrow-icon/flashcard-arrow-icon.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ReactComponent as FlashcardDownArrow } from '../../svg/flashcard-down-arrow.svg';
+import { ReactComponent as FlashcardDownArrow } from '@/assets/svg/flashcard-down-arrow.svg';
 import './flashcard-arrow-icon.scss';
 
 interface FlashcardArrowIconProps {

--- a/src/assets/icons/hamburger-menu-icon/hamburger-menu-icon.scss
+++ b/src/assets/icons/hamburger-menu-icon/hamburger-menu-icon.scss
@@ -1,5 +1,5 @@
-@import '../../colors';
-@import '../../styles';
+@import '@/assets/colors';
+@import '@/assets/styles';
 
 .hamburger-icon {
   &.dark path {

--- a/src/assets/icons/hamburger-menu-icon/hamburger-menu-icon.tsx
+++ b/src/assets/icons/hamburger-menu-icon/hamburger-menu-icon.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ReactComponent as HamburgerMenuSvg } from '../../svg/hamburger-menu.svg';
+import { ReactComponent as HamburgerMenuSvg } from '@/assets/svg/hamburger-menu.svg';
 import './hamburger-menu-icon.scss';
 
 interface HamburgerMenuIconProps {

--- a/src/assets/icons/incorrect-icon/incorrect-icon.scss
+++ b/src/assets/icons/incorrect-icon/incorrect-icon.scss
@@ -1,1 +1,1 @@
-@import '../../colors';
+@import '@/assets/colors';

--- a/src/assets/icons/incorrect-icon/incorrect-icon.tsx
+++ b/src/assets/icons/incorrect-icon/incorrect-icon.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ReactComponent as IncorrectSvg } from '../../svg/incorrect.svg';
+import { ReactComponent as IncorrectSvg } from '@/assets/svg/incorrect.svg';
 import './incorrect-icon.scss';
 
 interface IncorrectIconProps {

--- a/src/assets/icons/kebab-menu-icon/kabab-menu-icon.scss
+++ b/src/assets/icons/kebab-menu-icon/kabab-menu-icon.scss
@@ -1,5 +1,5 @@
-@import '../../colors';
-@import '../../styles';
+@import '@/assets/colors';
+@import '@/assets/styles';
 
 .kebab-icon {
   &.white path {

--- a/src/assets/icons/kebab-menu-icon/kebab-menu-icon.tsx
+++ b/src/assets/icons/kebab-menu-icon/kebab-menu-icon.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ReactComponent as KebabMenuSvg } from '../../svg/kebab-menu.svg';
+import { ReactComponent as KebabMenuSvg } from '@/assets/svg/kebab-menu.svg';
 import './kabab-menu-icon.scss';
 
 interface KebabMenuIconProps {

--- a/src/assets/icons/language-icon/language-icon.scss
+++ b/src/assets/icons/language-icon/language-icon.scss
@@ -1,4 +1,4 @@
-@import '../../colors';
+@import '@/assets/colors';
 
 .language-icon {
   &.dark {

--- a/src/assets/icons/language-icon/language-icon.tsx
+++ b/src/assets/icons/language-icon/language-icon.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ReactComponent as LanguageSvg } from '../../svg/language.svg';
+import { ReactComponent as LanguageSvg } from '@/assets/svg/language.svg';
 import './language-icon.scss';
 
 interface LanguageIconProps {

--- a/src/assets/icons/loading-icon/loading-icon.scss
+++ b/src/assets/icons/loading-icon/loading-icon.scss
@@ -1,5 +1,5 @@
-@import '../../colors';
-@import '../../styles';
+@import '@/assets/colors';
+@import '@/assets/styles';
 
 $color: $light-blue;
 

--- a/src/assets/icons/loading-icon/loading-icon.tsx
+++ b/src/assets/icons/loading-icon/loading-icon.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Fade } from '../../../animations/fade';
+import { Fade } from '@/animations/fade';
 import './loading-icon.scss';
 
 interface LoadingIconProps {

--- a/src/assets/icons/microphone-icon/microphone-icon.scss
+++ b/src/assets/icons/microphone-icon/microphone-icon.scss
@@ -1,2 +1,2 @@
-@import '../../colors';
-@import '../../styles';
+@import '@/assets/colors';
+@import '@/assets/styles';

--- a/src/assets/icons/microphone-icon/microphone-icon.tsx
+++ b/src/assets/icons/microphone-icon/microphone-icon.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { noop } from '../../../helpers/func';
-import { ReactComponent as MicrophoneIconSvg } from '../../svg/microphone.svg';
+import { ReactComponent as MicrophoneIconSvg } from '@/assets/svg/microphone.svg';
+import { noop } from '@/helpers/func';
 import './microphone-icon.scss';
 
 interface MicrophoneIconProps {

--- a/src/assets/icons/next-icon/next-icon.tsx
+++ b/src/assets/icons/next-icon/next-icon.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ReactComponent as NextSvg } from '../../svg/next.svg';
+import { ReactComponent as NextSvg } from '@/assets/svg/next.svg';
 import './next-icon.scss';
 
 interface NextIconProps {

--- a/src/assets/icons/pause-icon/pause-icon.tsx
+++ b/src/assets/icons/pause-icon/pause-icon.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ReactComponent as PauseSvg } from '../../svg/pause.svg';
+import { ReactComponent as PauseSvg } from '@/assets/svg/pause.svg';
 import './pause-icon.scss';
 
 interface PauseIconProps {

--- a/src/assets/icons/play-icon/play-icon.tsx
+++ b/src/assets/icons/play-icon/play-icon.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ReactComponent as PlaySvg } from '../../svg/play.svg';
+import { ReactComponent as PlaySvg } from '@/assets/svg/play.svg';
 import './play-icon.scss';
 
 interface PlayIconProps {

--- a/src/assets/icons/plus-icon/plus-icon.tsx
+++ b/src/assets/icons/plus-icon/plus-icon.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ReactComponent as PlusSvg } from '../../svg/plus.svg';
+import { ReactComponent as PlusSvg } from '@/assets/svg/plus.svg';
 import './plus-icon.scss';
 
 interface PlusIconProps {

--- a/src/assets/icons/previous-icon/previous-icon.tsx
+++ b/src/assets/icons/previous-icon/previous-icon.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ReactComponent as PreviousSvg } from '../../svg/previous.svg';
+import { ReactComponent as PreviousSvg } from '@/assets/svg/previous.svg';
 import './previous-icon.scss';
 
 interface PreviousIconProps {

--- a/src/assets/icons/reorder-icon/reorder-icon.scss
+++ b/src/assets/icons/reorder-icon/reorder-icon.scss
@@ -1,5 +1,5 @@
-@import '../../colors';
-@import '../../styles';
+@import '@/assets/colors';
+@import '@/assets/styles';
 
 svg.reorder-icon {
   @include standard-transition;

--- a/src/assets/icons/reorder-icon/reorder-icon.tsx
+++ b/src/assets/icons/reorder-icon/reorder-icon.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ReactComponent as ReorderSvg } from '../../svg/reorder.svg';
+import { ReactComponent as ReorderSvg } from '@/assets/svg/reorder.svg';
 import './reorder-icon.scss';
 
 interface ReorderIconProps {

--- a/src/assets/icons/skipped-icon/skipped-icon.scss
+++ b/src/assets/icons/skipped-icon/skipped-icon.scss
@@ -1,1 +1,1 @@
-@import '../../colors';
+@import '@/assets/colors';

--- a/src/assets/icons/skipped-icon/skipped-icon.tsx
+++ b/src/assets/icons/skipped-icon/skipped-icon.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ReactComponent as SkippedSvg } from '../../svg/skipped.svg';
+import { ReactComponent as SkippedSvg } from '@/assets/svg/skipped.svg';
 import './skipped-icon.scss';
 
 interface SkippedIconProps {

--- a/src/assets/icons/speaker-icon/speaker-icon.scss
+++ b/src/assets/icons/speaker-icon/speaker-icon.scss
@@ -1,5 +1,5 @@
-@import '../../colors';
-@import '../../styles';
+@import '@/assets/colors';
+@import '@/assets/styles';
 
 svg.speaker-icon.white path {
   &:first-child {

--- a/src/assets/icons/speaker-icon/speaker-icon.tsx
+++ b/src/assets/icons/speaker-icon/speaker-icon.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ReactComponent as SpeakerSvg } from '../../svg/speaker.svg';
+import { ReactComponent as SpeakerSvg } from '@/assets/svg/speaker.svg';
 import './speaker-icon.scss';
 
 interface SpeakerIconProps {

--- a/src/assets/icons/star-icon/star-icon.scss
+++ b/src/assets/icons/star-icon/star-icon.scss
@@ -1,1 +1,1 @@
-@import '../../colors';
+@import '@/assets/colors';

--- a/src/assets/icons/star-icon/star-icon.tsx
+++ b/src/assets/icons/star-icon/star-icon.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ReactComponent as StarSvg } from '../../svg/star.svg';
+import { ReactComponent as StarSvg } from '@/assets/svg/star.svg';
 import './star-icon.scss';
 
 interface StarIconProps {

--- a/src/assets/icons/swap-icon/swap-icon.scss
+++ b/src/assets/icons/swap-icon/swap-icon.scss
@@ -1,4 +1,4 @@
-@import '../../colors';
+@import '@/assets/colors';
 
 .swap-icon {
   &.dark {

--- a/src/assets/icons/swap-icon/swap-icon.tsx
+++ b/src/assets/icons/swap-icon/swap-icon.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ReactComponent as SwapSvg } from '../../svg/swap.svg';
+import { ReactComponent as SwapSvg } from '@/assets/svg/swap.svg';
 import './swap-icon.scss';
 
 interface SwapIconProps {

--- a/src/assets/icons/trash-icon/trash-icon.scss
+++ b/src/assets/icons/trash-icon/trash-icon.scss
@@ -1,5 +1,5 @@
-@import '../../colors';
-@import '../../styles';
+@import '@/assets/colors';
+@import '@/assets/styles';
 
 svg.trash-icon {
   @include standard-transition;

--- a/src/assets/icons/trash-icon/trash-icon.tsx
+++ b/src/assets/icons/trash-icon/trash-icon.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ReactComponent as Trash } from '../../svg/trash.svg';
+import { ReactComponent as Trash } from '@/assets/svg/trash.svg';
 import './trash-icon.scss';
 
 interface TrashIconProps {

--- a/src/components/audio-control-bar/audio-control-bar.scss
+++ b/src/components/audio-control-bar/audio-control-bar.scss
@@ -1,5 +1,5 @@
-@import '../../assets/colors';
-@import '../../assets/styles';
+@import '@/assets/colors';
+@import '@/assets/styles';
 
 .c-audio-control-bar {
   @include flex-center;

--- a/src/components/audio-control-bar/audio-control-bar.test.tsx
+++ b/src/components/audio-control-bar/audio-control-bar.test.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { noop } from '@/helpers/func';
 import { AudioControlBar } from './audio-control-bar';
-import { noop } from '../../helpers/func';
 
 describe('StudyFlashcard', () => {
   it('should render with the expected elements', () => {

--- a/src/components/audio-control-bar/audio-control-bar.tsx
+++ b/src/components/audio-control-bar/audio-control-bar.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
-import { NextIcon } from '../../assets/icons/next-icon/next-icon';
-import { PauseIcon } from '../../assets/icons/pause-icon/pause-icon';
-import { PlayIcon } from '../../assets/icons/play-icon/play-icon';
-import { PreviousIcon } from '../../assets/icons/previous-icon/previous-icon';
-import { Button } from '../button/button';
+import { NextIcon } from '@/assets/icons/next-icon/next-icon';
+import { PauseIcon } from '@/assets/icons/pause-icon/pause-icon';
+import { PlayIcon } from '@/assets/icons/play-icon/play-icon';
+import { PreviousIcon } from '@/assets/icons/previous-icon/previous-icon';
+import { Button } from '@/components/button/button';
 import './audio-control-bar.scss';
 
 interface AudioControlBarProps {

--- a/src/components/bubble-divider/bubble-divider.scss
+++ b/src/components/bubble-divider/bubble-divider.scss
@@ -1,5 +1,5 @@
-@import '../../assets/styles';
-@import '../../assets/colors';
+@import '@/assets/styles';
+@import '@/assets/colors';
 
 .c-bubble-divider {
   @include flex-center;

--- a/src/components/bubble-divider/bubble-divider.tsx
+++ b/src/components/bubble-divider/bubble-divider.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { AnimatePresence, motion } from 'framer-motion';
-import { ArrowIcon } from '../../assets/icons/arrow-icon/arrow-icon';
-import { Button } from '../button/button';
+import { ArrowIcon } from '@/assets/icons/arrow-icon/arrow-icon';
+import { Button } from '@/components/button/button';
 import './bubble-divider.scss';
 
 interface BubbleDividerProps {

--- a/src/components/button/button.scss
+++ b/src/components/button/button.scss
@@ -1,5 +1,6 @@
-@import '../../assets/colors';
-@import '../../assets/styles';
+@import '@/assets/colors';
+@import '@/assets/styles';
+
 .button {
   @include hover-pointer;
   padding: 3px 13px;

--- a/src/components/button/button.test.tsx
+++ b/src/components/button/button.test.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { noop } from '@/helpers/func';
 import { Button } from './button';
-import { noop } from '../../helpers/func';
 
 const TEST_CHILDREN = 'TEST_CHILDREN';
 

--- a/src/components/deck-cover/deck-cover.scss
+++ b/src/components/deck-cover/deck-cover.scss
@@ -1,5 +1,5 @@
-@import '../../assets/colors';
-@import '../../assets/styles';
+@import '@/assets/colors';
+@import '@/assets/styles';
 
 .deck-cover {
   margin: 10px;

--- a/src/components/deck-cover/deck-cover.test.tsx
+++ b/src/components/deck-cover/deck-cover.test.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { noop } from '@/helpers/func';
+import { testEnglishDeck } from '@/models/mock/deck.mock';
 import { DeckCover } from './deck-cover';
-import { noop } from '../../helpers/func';
-import { testEnglishDeck } from '../../models/mock/deck.mock';
 
 const TEST_DECK = testEnglishDeck(0);
 

--- a/src/components/deck-cover/deck-cover.tsx
+++ b/src/components/deck-cover/deck-cover.tsx
@@ -1,9 +1,9 @@
 import React, { useState } from 'react';
 import { motion } from 'framer-motion';
-import { Deck } from '../../models/deck';
-import { Button } from '../button/button';
-import { FlipTile } from '../flip-tile/flip-tile';
-import { ProgressBar } from '../progress-bar/progress-bar';
+import { Button } from '@/components/button/button';
+import { FlipTile } from '@/components/flip-tile/flip-tile';
+import { ProgressBar } from '@/components/progress-bar/progress-bar';
+import { Deck } from '@/models/deck';
 import './deck-cover.scss';
 
 interface DeckCoverProps {

--- a/src/components/drop-down-options/drop-down-options.scss
+++ b/src/components/drop-down-options/drop-down-options.scss
@@ -1,5 +1,5 @@
-@import '../../assets/colors';
-@import '../../assets/styles';
+@import '@/assets/colors';
+@import '@/assets/styles';
 
 .c-drop-down-options {
   @include floating-card;

--- a/src/components/drop-down-options/drop-down-options.test.tsx
+++ b/src/components/drop-down-options/drop-down-options.test.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { noop } from '@/helpers/func';
+import { withFakeTimers } from '@/helpers/test';
 import { DropDownOption, DropDownOptions } from './drop-down-options';
 import {
   TEST_OPTIONS_SINGLE,
@@ -8,8 +10,6 @@ import {
   TEST_OPTIONS_SMALL,
   TEST_OPTIONS_SMALL_VALUES,
 } from './options.mock';
-import { noop } from '../../helpers/func';
-import { withFakeTimers } from '../../helpers/test';
 
 describe('DropDownOptions', () => {
   it('should render correctly with default props', () => {

--- a/src/components/drop-down-options/drop-down-options.tsx
+++ b/src/components/drop-down-options/drop-down-options.tsx
@@ -1,7 +1,7 @@
 import React, { ReactNode } from 'react';
 import { AnimatePresence } from 'framer-motion';
-import { Fade } from '../../animations/fade';
-import { Button } from '../button/button';
+import { Fade } from '@/animations/fade';
+import { Button } from '@/components/button/button';
 import './drop-down-options.scss';
 
 /**

--- a/src/components/drop-down/drop-down.scss
+++ b/src/components/drop-down/drop-down.scss
@@ -1,5 +1,5 @@
-@import '../../assets/colors';
-@import '../../assets/styles';
+@import '@/assets/colors';
+@import '@/assets/styles';
 
 .drop-down {
   > label {

--- a/src/components/drop-down/drop-down.test.tsx
+++ b/src/components/drop-down/drop-down.test.tsx
@@ -1,9 +1,12 @@
 import React from 'react';
 import { render, screen, waitForElementToBeRemoved } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import {
+  TEST_OPTIONS_SMALL,
+  TEST_OPTIONS_SMALL_VALUES,
+} from '@/components/drop-down-options/options.mock';
+import { noop } from '@/helpers/func';
 import { DropDown } from './drop-down';
-import { noop } from '../../helpers/func';
-import { TEST_OPTIONS_SMALL, TEST_OPTIONS_SMALL_VALUES } from '../drop-down-options/options.mock';
 
 const TEST_LABEL = 'TEST_LABEL';
 const TEST_BUTTON_LABEL = 'TEST_BUTTON_LABEL';

--- a/src/components/drop-down/drop-down.tsx
+++ b/src/components/drop-down/drop-down.tsx
@@ -1,10 +1,10 @@
 import React, { ReactNode, useRef, useState } from 'react';
-import { ArrowIcon } from '../../assets/icons/arrow-icon/arrow-icon';
-import { useFocusTrap } from '../../hooks/use-focus-trap';
-import { useEscapePress } from '../../hooks/use-key-press';
-import { useOutsideClick } from '../../hooks/use-outside-click';
-import { Button } from '../button/button';
-import { DropDownOption, DropDownOptions } from '../drop-down-options/drop-down-options';
+import { ArrowIcon } from '@/assets/icons/arrow-icon/arrow-icon';
+import { Button } from '@/components/button/button';
+import { DropDownOption, DropDownOptions } from '@/components/drop-down-options/drop-down-options';
+import { useFocusTrap } from '@/hooks/use-focus-trap';
+import { useEscapePress } from '@/hooks/use-key-press';
+import { useOutsideClick } from '@/hooks/use-outside-click';
 import './drop-down.scss';
 
 interface DropDownProps<I, V> {

--- a/src/components/file-input/file-input.scss
+++ b/src/components/file-input/file-input.scss
@@ -1,5 +1,6 @@
-@import '../../assets/colors';
-@import '../../assets/styles';
+@import '@/assets/colors';
+@import '@/assets/styles';
+
 .c-file-input {
   border: 1px solid $grey;
   padding: 10px 15px;

--- a/src/components/file-input/file-input.test.tsx
+++ b/src/components/file-input/file-input.test.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { noop } from '@/helpers/func';
 import { FileInput, ImportedFile } from './file-input';
-import { noop } from '../../helpers/func';
 
 describe('FileInput', () => {
   let testLabel: string;

--- a/src/components/file-input/file-input.tsx
+++ b/src/components/file-input/file-input.tsx
@@ -1,11 +1,11 @@
 import React, { useState } from 'react';
 import { v4 as uuidv4 } from 'uuid';
+import { CancelIcon } from '@/assets/icons/cancel-icon/cancel-icon';
+import { DocIcon } from '@/assets/icons/doc-icon/doc-icon';
+import { LoadingIcon } from '@/assets/icons/loading-icon/loading-icon';
+import { Button } from '@/components/button/button';
+import { noop } from '@/helpers/func';
 import { readFile } from './file-reader';
-import { CancelIcon } from '../../assets/icons/cancel-icon/cancel-icon';
-import { DocIcon } from '../../assets/icons/doc-icon/doc-icon';
-import { LoadingIcon } from '../../assets/icons/loading-icon/loading-icon';
-import { noop } from '../../helpers/func';
-import { Button } from '../button/button';
 import './file-input.scss';
 
 export interface ImportedFile {

--- a/src/components/flashcard-set/flashcard-set.scss
+++ b/src/components/flashcard-set/flashcard-set.scss
@@ -1,5 +1,5 @@
-@import '../../assets/colors';
-@import '../../assets/styles';
+@import '@/assets/colors';
+@import '@/assets/styles';
 
 .c-flashcard-set ul {
   list-style-type: none;

--- a/src/components/flashcard-set/flashcard-set.test.tsx
+++ b/src/components/flashcard-set/flashcard-set.test.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { noop } from '@/helpers/func';
+import { Card } from '@/models/card';
+import { getTestFoxCard, getTestMonkeyCard, getTestMouseCard } from '@/models/mock/card.mock';
 import { FlashcardSet } from './flashcard-set';
-import { noop } from '../../helpers/func';
-import { Card } from '../../models/card';
-import { getTestFoxCard, getTestMonkeyCard, getTestMouseCard } from '../../models/mock/card.mock';
 
 describe('FlashcardSet', () => {
   let TEST_FOX_CARD: Card;

--- a/src/components/flashcard-set/flashcard-set.tsx
+++ b/src/components/flashcard-set/flashcard-set.tsx
@@ -1,10 +1,10 @@
 import React, { useEffect, useState } from 'react';
 import { Reorder, useDragControls } from 'framer-motion';
-import { TrashIcon } from '../../assets/icons/trash-icon/trash-icon';
-import { Card } from '../../models/card';
-import { Button } from '../button/button';
-import { Flashcard } from '../flashcard/flashcard';
-import { ReorderButtonStrip } from '../flashcard/reorder-button-strip/reorder-button-strip';
+import { TrashIcon } from '@/assets/icons/trash-icon/trash-icon';
+import { Button } from '@/components/button/button';
+import { Flashcard } from '@/components/flashcard/flashcard';
+import { ReorderButtonStrip } from '@/components/flashcard/reorder-button-strip/reorder-button-strip';
+import { Card } from '@/models/card';
 import './flashcard-set.scss';
 
 interface FlashcardSetProps {

--- a/src/components/flashcard/card-face/card-face.scss
+++ b/src/components/flashcard/card-face/card-face.scss
@@ -1,5 +1,5 @@
-@import '../../../assets/colors';
-@import '../../../assets/styles';
+@import '@/assets/colors';
+@import '@/assets/styles';
 
 $button-strip-height: 35px;
 

--- a/src/components/flashcard/card-face/card-face.test.tsx
+++ b/src/components/flashcard/card-face/card-face.test.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { noop } from '@/helpers/func';
+import { createNewCardContent } from '@/models/card-content';
 import { CardFace } from './card-face';
-import { noop } from '../../../helpers/func';
-import { createNewCardContent } from '../../../models/card-content';
 
 describe('CardFace', () => {
   it('should hide kebab menu when inactive', () => {

--- a/src/components/flashcard/card-face/card-face.tsx
+++ b/src/components/flashcard/card-face/card-face.tsx
@@ -1,8 +1,8 @@
 import React, { useRef } from 'react';
 import TextareaAutoSize from 'react-textarea-autosize';
+import { CardContent } from '@/models/card-content';
+import { CardLanguage } from '@/models/language';
 import { CardMenu } from './card-menu/card-menu';
-import { CardContent } from '../../../models/card-content';
-import { CardLanguage } from '../../../models/language';
 import './card-face.scss';
 
 interface CardFaceProps {

--- a/src/components/flashcard/card-face/card-menu/card-menu.scss
+++ b/src/components/flashcard/card-face/card-menu/card-menu.scss
@@ -1,5 +1,5 @@
-@import '../../../../assets/colors';
-@import '../../../../assets/styles';
+@import '@/assets/colors';
+@import '@/assets/styles';
 
 .c-card-menu {
   position: absolute;

--- a/src/components/flashcard/card-face/card-menu/card-menu.test.tsx
+++ b/src/components/flashcard/card-face/card-menu/card-menu.test.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { noop } from '@/helpers/func';
 import { CardMenu } from './card-menu';
-import { noop } from '../../../../helpers/func';
 
 describe('CardMenu', () => {
   const TEST_CHANGE_LANGUAGE_LABEL = 'TEST_CHANGE_LANGUAGE_LABEL';

--- a/src/components/flashcard/card-face/card-menu/card-menu.tsx
+++ b/src/components/flashcard/card-face/card-menu/card-menu.tsx
@@ -1,9 +1,9 @@
 import React, { ReactNode, useState } from 'react';
-import { SwapIcon } from '../../../../assets/icons/swap-icon/swap-icon';
-import { AllCardLanguages, CardLanguage } from '../../../../models/language';
-import { DropDownOption } from '../../../drop-down-options/drop-down-options';
-import { KebabMenu } from '../../../kebab-menu/kebab-menu';
-import { LanguageDropDown } from '../../../language-drop-down/drop-down-options/language-drop-down';
+import { SwapIcon } from '@/assets/icons/swap-icon/swap-icon';
+import { DropDownOption } from '@/components/drop-down-options/drop-down-options';
+import { KebabMenu } from '@/components/kebab-menu/kebab-menu';
+import { LanguageDropDown } from '@/components/language-drop-down/drop-down-options/language-drop-down';
+import { AllCardLanguages, CardLanguage } from '@/models/language';
 import './card-menu.scss';
 
 const langDropdownId = 'lang';

--- a/src/components/flashcard/flashcard.scss
+++ b/src/components/flashcard/flashcard.scss
@@ -1,4 +1,4 @@
-@import '../../assets/styles';
+@import '@/assets/styles';
 
 .flashcard {
   @include flex-center;

--- a/src/components/flashcard/flashcard.test.tsx
+++ b/src/components/flashcard/flashcard.test.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { noop } from '@/helpers/func';
+import { Card, createNewCard } from '@/models/card';
+import { getTestFoxCard } from '@/models/mock/card.mock';
 import { Flashcard } from './flashcard';
-import { noop } from '../../helpers/func';
-import { Card, createNewCard } from '../../models/card';
-import { getTestFoxCard } from '../../models/mock/card.mock';
 
 describe('Flashcard', () => {
   it('should render correctly when inactive', () => {

--- a/src/components/flashcard/flashcard.tsx
+++ b/src/components/flashcard/flashcard.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef } from 'react';
+import { Card } from '@/models/card';
+import { CardContent } from '@/models/card-content';
 import { CardFace } from './card-face/card-face';
-import { Card } from '../../models/card';
-import { CardContent } from '../../models/card-content';
 import './flashcard.scss';
 
 interface FlashcardProps {

--- a/src/components/flashcard/reorder-button-strip/reorder-button-strip.scss
+++ b/src/components/flashcard/reorder-button-strip/reorder-button-strip.scss
@@ -1,4 +1,4 @@
-@import '../../../assets/styles';
+@import '@/assets/styles';
 
 .reorder-button-strip {
   height: 75%;

--- a/src/components/flashcard/reorder-button-strip/reorder-button-strip.tsx
+++ b/src/components/flashcard/reorder-button-strip/reorder-button-strip.tsx
@@ -1,8 +1,8 @@
 import React, { useState } from 'react';
 import { AnimatePresence, motion } from 'framer-motion';
-import { FlashcardArrowIcon } from '../../../assets/icons/flashcard-arrow-icon/flashcard-arrow-icon';
-import { ReorderIcon } from '../../../assets/icons/reorder-icon/reorder-icon';
-import { Button } from '../../button/button';
+import { FlashcardArrowIcon } from '@/assets/icons/flashcard-arrow-icon/flashcard-arrow-icon';
+import { ReorderIcon } from '@/assets/icons/reorder-icon/reorder-icon';
+import { Button } from '@/components/button/button';
 import './reorder-button-strip.scss';
 
 interface ReorderButtonStripProps {

--- a/src/components/flip-tile/flip-tile.scss
+++ b/src/components/flip-tile/flip-tile.scss
@@ -1,5 +1,5 @@
-@import '../../assets/colors';
-@import '../../assets/styles';
+@import '@/assets/colors';
+@import '@/assets/styles';
 
 .c-flip-tile {
   width: 325px;

--- a/src/components/flip-tile/flip-tile.test.tsx
+++ b/src/components/flip-tile/flip-tile.test.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { noop } from '@/helpers/func';
 import { FlipTile } from './flip-tile';
-import { noop } from '../../helpers/func';
 
 const TEST_FRONT = 'TEST_FRONT';
 const TEST_BACK = 'TEST_BACK';

--- a/src/components/header/account-popup/account-popup.scss
+++ b/src/components/header/account-popup/account-popup.scss
@@ -1,6 +1,6 @@
 @import url('https://fonts.googleapis.com/css2?family=Comfortaa:wght@300;700&display=swap');
-@import '../../../assets/colors';
-@import '../../../assets/styles';
+@import '@/assets/colors';
+@import '@/assets/styles';
 
 $bg-opacity: 0; // opacity to set background if modal is open
 

--- a/src/components/header/account-popup/account-popup.test.tsx
+++ b/src/components/header/account-popup/account-popup.test.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { renderWithTestRoots } from '@/app.test';
+import { noop } from '@/helpers/func';
 import { AccountPopup } from './account-popup';
-import { renderWithTestRoots } from '../../../app.test';
-import { noop } from '../../../helpers/func';
 
 describe('AccountPopup', () => {
   const DEFAULT_CHILDREN = <div>test123</div>;

--- a/src/components/header/account-popup/account-popup.tsx
+++ b/src/components/header/account-popup/account-popup.tsx
@@ -1,10 +1,10 @@
 import React, { useRef } from 'react';
 import ReactDOM from 'react-dom';
-import { CancelIcon } from '../../../assets/icons/cancel-icon/cancel-icon';
-import { useFocusFirst } from '../../../hooks/use-focus-first';
-import { useFocusTrap } from '../../../hooks/use-focus-trap';
-import { useEscapePress } from '../../../hooks/use-key-press';
-import { useOutsideClick } from '../../../hooks/use-outside-click';
+import { CancelIcon } from '@/assets/icons/cancel-icon/cancel-icon';
+import { useFocusFirst } from '@/hooks/use-focus-first';
+import { useFocusTrap } from '@/hooks/use-focus-trap';
+import { useEscapePress } from '@/hooks/use-key-press';
+import { useOutsideClick } from '@/hooks/use-outside-click';
 import './account-popup.scss';
 
 export interface AccountPopupProps {

--- a/src/components/header/header.scss
+++ b/src/components/header/header.scss
@@ -1,5 +1,5 @@
-@import '../../assets/colors';
-@import '../../assets/styles';
+@import '@/assets/colors';
+@import '@/assets/styles';
 
 $search-bar-offset: ($content-padding - $header-gap);
 

--- a/src/components/header/header.test.tsx
+++ b/src/components/header/header.test.tsx
@@ -2,11 +2,11 @@ import React from 'react';
 import { fireEvent, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MutableSnapshot } from 'recoil';
+import { renderWithTestRoots } from '@/app.test';
+import { testEnglishDeck } from '@/models/mock/deck.mock';
+import { paths } from '@/routing/paths';
+import { userDecksState } from '@/state/user-decks';
 import { Header } from './header';
-import { renderWithTestRoots } from '../../app.test';
-import { testEnglishDeck } from '../../models/mock/deck.mock';
-import { paths } from '../../routing/paths';
-import { userDecksState } from '../../state/user-decks';
 
 describe('Header', () => {
   it('should render correctly with default props', () => {

--- a/src/components/header/header.tsx
+++ b/src/components/header/header.tsx
@@ -2,17 +2,17 @@ import React from 'react';
 import { useNavigate } from 'react-router-dom';
 import { AnimatePresence, motion } from 'framer-motion';
 import { useRecoilState, useRecoilValue } from 'recoil';
+import { CancelIcon } from '@/assets/icons/cancel-icon/cancel-icon';
+import { HamburgerMenuIcon } from '@/assets/icons/hamburger-menu-icon/hamburger-menu-icon';
+import { Button } from '@/components/button/button';
+import { DropDownOption } from '@/components/drop-down-options/drop-down-options';
+import { SearchBar } from '@/components/search-bar/search-bar';
+import { useUserClient } from '@/hooks/api/use-user-client';
+import { paths } from '@/routing/paths';
+import { authJwtState, isAuthJwt } from '@/state/auth-jwt';
+import { navToggledState } from '@/state/nav';
+import { userDecksSortedState } from '@/state/user-decks';
 import { WelcomeUser } from './welcome-user/welcome-user';
-import { CancelIcon } from '../../assets/icons/cancel-icon/cancel-icon';
-import { HamburgerMenuIcon } from '../../assets/icons/hamburger-menu-icon/hamburger-menu-icon';
-import { useUserClient } from '../../hooks/api/use-user-client';
-import { paths } from '../../routing/paths';
-import { authJwtState, isAuthJwt } from '../../state/auth-jwt';
-import { navToggledState } from '../../state/nav';
-import { userDecksSortedState } from '../../state/user-decks';
-import { Button } from '../button/button';
-import { DropDownOption } from '../drop-down-options/drop-down-options';
-import { SearchBar } from '../search-bar/search-bar';
 import './header.scss';
 
 interface HeaderProps {

--- a/src/components/header/welcome-user/welcome-user.scss
+++ b/src/components/header/welcome-user/welcome-user.scss
@@ -1,5 +1,5 @@
-@import '../../../assets/colors';
-@import '../../../assets/styles';
+@import '@/assets/colors';
+@import '@/assets/styles';
 
 // popup styles
 .welcome-account-popup {

--- a/src/components/header/welcome-user/welcome-user.test.tsx
+++ b/src/components/header/welcome-user/welcome-user.test.tsx
@@ -4,10 +4,10 @@ import { act, renderHook } from '@testing-library/react-hooks';
 import userEvent from '@testing-library/user-event';
 import { enableFetchMocks } from 'jest-fetch-mock';
 import { MutableSnapshot } from 'recoil';
+import { renderWithTestRoots } from '@/app.test';
+import { authJwtState, UserInfo, userInfoStateAsync } from '@/state/auth-jwt';
+import { userDecksState } from '@/state/user-decks';
 import { WelcomeUser } from './welcome-user';
-import { renderWithTestRoots } from '../../../app.test';
-import { authJwtState, UserInfo, userInfoStateAsync } from '../../../state/auth-jwt';
-import { userDecksState } from '../../../state/user-decks';
 
 // provide fetchMock global and disable mocking initially
 enableFetchMocks();

--- a/src/components/header/welcome-user/welcome-user.tsx
+++ b/src/components/header/welcome-user/welcome-user.tsx
@@ -1,9 +1,9 @@
 import React, { useState } from 'react';
 import { useRecoilValue } from 'recoil';
-import { useUserClient } from '../../../hooks/api/use-user-client';
-import { userInfoStateAsync } from '../../../state/auth-jwt';
-import { Button } from '../../button/button';
-import { AccountPopup } from '../account-popup/account-popup';
+import { Button } from '@/components/button/button';
+import { AccountPopup } from '@/components/header/account-popup/account-popup';
+import { useUserClient } from '@/hooks/api/use-user-client';
+import { userInfoStateAsync } from '@/state/auth-jwt';
 import './welcome-user.scss';
 
 interface WelcomeUserProps {

--- a/src/components/kebab-menu/kebab-menu.tsx
+++ b/src/components/kebab-menu/kebab-menu.tsx
@@ -1,10 +1,10 @@
 import React, { ReactNode, useRef } from 'react';
-import { KebabMenuIcon } from '../../assets/icons/kebab-menu-icon/kebab-menu-icon';
-import { useFocusTrap } from '../../hooks/use-focus-trap';
-import { useEscapePress } from '../../hooks/use-key-press';
-import { useOutsideClick } from '../../hooks/use-outside-click';
-import { Button } from '../button/button';
-import { DropDownOption, DropDownOptions } from '../drop-down-options/drop-down-options';
+import { KebabMenuIcon } from '@/assets/icons/kebab-menu-icon/kebab-menu-icon';
+import { Button } from '@/components/button/button';
+import { DropDownOption, DropDownOptions } from '@/components/drop-down-options/drop-down-options';
+import { useFocusTrap } from '@/hooks/use-focus-trap';
+import { useEscapePress } from '@/hooks/use-key-press';
+import { useOutsideClick } from '@/hooks/use-outside-click';
 import './kebab-menu.scss';
 
 interface KebabMenuProps<I, V> {

--- a/src/components/language-drop-down/drop-down-options/language-drop-down.scss
+++ b/src/components/language-drop-down/drop-down-options/language-drop-down.scss
@@ -1,5 +1,5 @@
-@import '../../../assets/colors';
-@import '../../../assets/styles';
+@import '@/assets/colors';
+@import '@/assets/styles';
 
 .c-language-drop-down {
   display: flex;

--- a/src/components/language-drop-down/drop-down-options/language-drop-down.tsx
+++ b/src/components/language-drop-down/drop-down-options/language-drop-down.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
-import { LanguageIcon } from '../../../assets/icons/language-icon/language-icon';
-import { CardLanguages, DeckLanguages } from '../../../models/language';
-import { DropDown } from '../../drop-down/drop-down';
-import { DropDownOption } from '../../drop-down-options/drop-down-options';
+import { LanguageIcon } from '@/assets/icons/language-icon/language-icon';
+import { DropDown } from '@/components/drop-down/drop-down';
+import { DropDownOption } from '@/components/drop-down-options/drop-down-options';
+import { CardLanguages, DeckLanguages } from '@/models/language';
 import './language-drop-down.scss';
 
 interface LanguageDropDownProps<T extends DeckLanguages | CardLanguages> {

--- a/src/components/loading-page/loading-page.scss
+++ b/src/components/loading-page/loading-page.scss
@@ -1,5 +1,6 @@
-@import '../../assets/colors';
-@import '../../assets/styles';
+@import '@/assets/colors';
+@import '@/assets/styles';
+
 .c-loading-page {
   margin-top: 150px;
   width: 100%;

--- a/src/components/loading-page/loading-page.tsx
+++ b/src/components/loading-page/loading-page.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { motion } from 'framer-motion';
-import { LoadingIcon } from '../../assets/icons/loading-icon/loading-icon';
+import { LoadingIcon } from '@/assets/icons/loading-icon/loading-icon';
 import './loading-page.scss';
 
 interface LoadingPageProps {

--- a/src/components/page-header/page-header.scss
+++ b/src/components/page-header/page-header.scss
@@ -1,4 +1,4 @@
-@import '../../assets/styles';
+@import '@/assets/styles';
 
 .c-page-header {
   display: flex;

--- a/src/components/page-header/page-header.test.tsx
+++ b/src/components/page-header/page-header.test.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { noop } from '@/helpers/func';
 import { PageHeader } from './page-header';
-import { noop } from '../../helpers/func';
 
 const TEST_LABEL = 'TEST_LABEL';
 const TEST_GO_BACK_LABEL = 'TEST_GO_BACK_LABEL';

--- a/src/components/page-header/page-header.tsx
+++ b/src/components/page-header/page-header.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { BackArrowIcon } from '../../assets/icons/back-arrow-icon/back-arrow-icon';
-import { Button } from '../button/button';
+import { BackArrowIcon } from '@/assets/icons/back-arrow-icon/back-arrow-icon';
+import { Button } from '@/components/button/button';
 import './page-header.scss';
 
 interface PageHeaderProps {

--- a/src/components/popup-modal/popup-modal.scss
+++ b/src/components/popup-modal/popup-modal.scss
@@ -1,6 +1,6 @@
 @import url('https://fonts.googleapis.com/css2?family=Comfortaa:wght@300;700&display=swap');
-@import '../../assets/colors';
-@import '../../assets/styles';
+@import '@/assets/colors';
+@import '@/assets/styles';
 
 $bg-opacity: 0.33; // opacity to set background if modal is open
 $x-axis: 50%; // where to place popup on x-axis

--- a/src/components/popup-modal/popup-modal.tsx
+++ b/src/components/popup-modal/popup-modal.tsx
@@ -1,10 +1,10 @@
 import React, { useRef } from 'react';
 import ReactDOM from 'react-dom';
-import { CancelIcon } from '../../assets/icons/cancel-icon/cancel-icon';
-import { useFocusFirst } from '../../hooks/use-focus-first';
-import { useFocusTrap } from '../../hooks/use-focus-trap';
-import { useEscapePress } from '../../hooks/use-key-press';
-import { useOutsideClick } from '../../hooks/use-outside-click';
+import { CancelIcon } from '@/assets/icons/cancel-icon/cancel-icon';
+import { useFocusFirst } from '@/hooks/use-focus-first';
+import { useFocusTrap } from '@/hooks/use-focus-trap';
+import { useEscapePress } from '@/hooks/use-key-press';
+import { useOutsideClick } from '@/hooks/use-outside-click';
 import './popup-modal.scss';
 
 export interface PopupModalProps {

--- a/src/components/progress-bar/progress-bar.scss
+++ b/src/components/progress-bar/progress-bar.scss
@@ -1,5 +1,5 @@
-@import '../../assets/colors';
-@import '../../assets/styles';
+@import '@/assets/colors';
+@import '@/assets/styles';
 
 $height: 15px;
 

--- a/src/components/progress-bar/progress-bar.tsx
+++ b/src/components/progress-bar/progress-bar.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { motion } from 'framer-motion';
-import { clamp } from '../../helpers/func';
+import { clamp } from '@/helpers/func';
 import './progress-bar.scss';
 
 interface ProgressBarProps {

--- a/src/components/radio-button-group/radio-button-group.scss
+++ b/src/components/radio-button-group/radio-button-group.scss
@@ -1,5 +1,6 @@
-@import '../../assets/styles';
-@import '../../assets/colors';
+@import '@/assets/styles';
+@import '@/assets/colors';
+
 .radio-button-group {
   display: flex;
   gap: 10px;

--- a/src/components/radio-button-group/radio-button-group.tsx
+++ b/src/components/radio-button-group/radio-button-group.tsx
@@ -1,5 +1,5 @@
 import React, { ReactNode } from 'react';
-import { Button } from '../../components/button/button';
+import { Button } from '@/components/button/button';
 import './radio-button-group.scss';
 
 export type RadioButtonOption<I extends string, V extends ReactNode> = { id: I; value: V };

--- a/src/components/read-only-flashcard/read-only-flashcard.scss
+++ b/src/components/read-only-flashcard/read-only-flashcard.scss
@@ -1,5 +1,5 @@
-@import '../../assets/styles';
-@import '../../assets/colors';
+@import '@/assets/styles';
+@import '@/assets/colors';
 
 $content-top-bottom-margin: 10px;
 $card-height: 175px;

--- a/src/components/read-only-flashcard/read-only-flashcard.test.tsx
+++ b/src/components/read-only-flashcard/read-only-flashcard.test.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { noop } from '@/helpers/func';
+import { getTestMonkeyCard } from '@/models/mock/card.mock';
 import { ReadOnlyFlashcard } from './read-only-flashcard';
-import { noop } from '../../helpers/func';
-import { getTestMonkeyCard } from '../../models/mock/card.mock';
 
 describe('ReadOnlyFlashcard', () => {
   it('should render correctly when readonly', () => {

--- a/src/components/read-only-flashcard/read-only-flashcard.tsx
+++ b/src/components/read-only-flashcard/read-only-flashcard.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { SpeakerIcon } from '../../assets/icons/speaker-icon/speaker-icon';
-import { Button } from '../button/button';
+import { SpeakerIcon } from '@/assets/icons/speaker-icon/speaker-icon';
+import { Button } from '@/components/button/button';
 import './read-only-flashcard.scss';
 
 export type ReadOnlyFlashcardVariant = 'red' | 'green' | 'light-blue';

--- a/src/components/registration-panel/registration-panel.scss
+++ b/src/components/registration-panel/registration-panel.scss
@@ -1,5 +1,5 @@
-@import '../../assets/styles';
-@import '../../assets/colors';
+@import '@/assets/styles';
+@import '@/assets/colors';
 
 .registration-component-wrapper {
   display: flex;

--- a/src/components/registration-panel/registration-panel.tsx
+++ b/src/components/registration-panel/registration-panel.tsx
@@ -1,12 +1,12 @@
 import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { Fade } from '../../animations/fade';
-import { UpToggle } from '../../animations/up-toggle';
-import { LoadingIcon } from '../../assets/icons/loading-icon/loading-icon';
-import { BubbleDivider } from '../../components/bubble-divider/bubble-divider';
-import { Button } from '../../components/button/button';
-import { useUserClient } from '../../hooks/api/use-user-client';
-import { paths } from '../../routing/paths';
+import { Fade } from '@/animations/fade';
+import { UpToggle } from '@/animations/up-toggle';
+import { LoadingIcon } from '@/assets/icons/loading-icon/loading-icon';
+import { BubbleDivider } from '@/components/bubble-divider/bubble-divider';
+import { Button } from '@/components/button/button';
+import { useUserClient } from '@/hooks/api/use-user-client';
+import { paths } from '@/routing/paths';
 import './registration-panel.scss';
 
 interface RegistrationPanelProps {

--- a/src/components/resource-loader/resource-loader.tsx
+++ b/src/components/resource-loader/resource-loader.tsx
@@ -1,9 +1,9 @@
 import React, { useEffect, useState } from 'react';
 import { useLocation, useParams } from 'react-router-dom';
-import { useCardsClient } from '../../hooks/api/use-cards-client';
-import { useDecksClient } from '../../hooks/api/use-decks-client';
-import { createNewDeck } from '../../models/deck';
-import { LoadingPage } from '../loading-page/loading-page';
+import { LoadingPage } from '@/components/loading-page/loading-page';
+import { useCardsClient } from '@/hooks/api/use-cards-client';
+import { useDecksClient } from '@/hooks/api/use-decks-client';
+import { createNewDeck } from '@/models/deck';
 
 interface ResourceLoaderProps<T> {
   routeParameter: string;

--- a/src/components/search-bar/search-bar.scss
+++ b/src/components/search-bar/search-bar.scss
@@ -1,6 +1,6 @@
 @import url('https://fonts.googleapis.com/css2?family=Comfortaa:wght@300;700&display=swap');
-@import '../../assets/colors';
-@import '../../assets/styles';
+@import '@/assets/colors';
+@import '@/assets/styles';
 
 // probably need to make all these props
 $height: 40px;

--- a/src/components/search-bar/search-bar.test.tsx
+++ b/src/components/search-bar/search-bar.test.tsx
@@ -7,12 +7,12 @@ import {
   waitForElementToBeRemoved,
 } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { SearchBar } from './search-bar';
 import {
   TEST_OPTIONS_SINGLE,
   TEST_OPTIONS_SMALL,
   TEST_OPTIONS_SMALL_VALUES,
-} from '../drop-down-options/options.mock';
+} from '@/components/drop-down-options/options.mock';
+import { SearchBar } from './search-bar';
 
 const TEST_PLACEHOLDER = 'TEST_PLACEHOLDER';
 const TEST_INITIAL_TEXT = 'TEST_INITIAL_TEXT';

--- a/src/components/search-bar/search-bar.tsx
+++ b/src/components/search-bar/search-bar.tsx
@@ -1,13 +1,13 @@
 import React, { ChangeEvent, KeyboardEvent, useMemo, useRef, useState } from 'react';
-import { CancelIcon } from '../../assets/icons/cancel-icon/cancel-icon';
-import { ReactComponent as SearchIcon } from '../../assets/svg/search-icon.svg';
-import { debounce, noop } from '../../helpers/func';
-import { includesIgnoreCase } from '../../helpers/string';
-import { useFocusTrap } from '../../hooks/use-focus-trap';
-import { useEscapePress } from '../../hooks/use-key-press';
-import { useOutsideClick } from '../../hooks/use-outside-click';
-import { Button } from '../button/button';
-import { DropDownOption, DropDownOptions } from '../drop-down-options/drop-down-options';
+import { CancelIcon } from '@/assets/icons/cancel-icon/cancel-icon';
+import { ReactComponent as SearchIcon } from '@/assets/svg/search-icon.svg';
+import { Button } from '@/components/button/button';
+import { DropDownOption, DropDownOptions } from '@/components/drop-down-options/drop-down-options';
+import { debounce, noop } from '@/helpers/func';
+import { includesIgnoreCase } from '@/helpers/string';
+import { useFocusTrap } from '@/hooks/use-focus-trap';
+import { useEscapePress } from '@/hooks/use-key-press';
+import { useOutsideClick } from '@/hooks/use-outside-click';
 import './search-bar.scss';
 
 export interface SearchBarProps {

--- a/src/components/sidebar/sidebar.scss
+++ b/src/components/sidebar/sidebar.scss
@@ -1,5 +1,5 @@
-@import '../../assets/colors';
-@import '../../assets/styles';
+@import '@/assets/colors';
+@import '@/assets/styles';
 
 .c-sidebar {
   width: $sidebar-width;

--- a/src/components/sidebar/sidebar.test.tsx
+++ b/src/components/sidebar/sidebar.test.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { renderWithTestRoots } from '@/app.test';
+import { SIDEBAR_ROUTE_ITEMS } from '@/routing/sidebar-routes';
 import { Sidebar } from './sidebar';
-import { renderWithTestRoots } from '../../app.test';
-import { SIDEBAR_ROUTE_ITEMS } from '../../routing/sidebar-routes';
 
 const FIRST_SIDEBAR_ITEM_NAME = SIDEBAR_ROUTE_ITEMS[0].name;
 const FIRST_SIDEBAR_ITEM_ROUTE = SIDEBAR_ROUTE_ITEMS[0].route;

--- a/src/components/sidebar/sidebar.tsx
+++ b/src/components/sidebar/sidebar.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { NavLink } from 'react-router-dom';
 import { useRecoilValue } from 'recoil';
-import { SIDEBAR_ROUTE_ITEMS } from '../../routing/sidebar-routes';
-import { navToggledState } from '../../state/nav';
+import { SIDEBAR_ROUTE_ITEMS } from '@/routing/sidebar-routes';
+import { navToggledState } from '@/state/nav';
 import './sidebar.scss';
 
 interface SidebarProps {

--- a/src/components/study-flashcard/study-flashcard.scss
+++ b/src/components/study-flashcard/study-flashcard.scss
@@ -1,4 +1,4 @@
-@import '../../assets/styles';
+@import '@/assets/styles';
 
 .study-card {
   width: 450px;

--- a/src/components/study-flashcard/study-flashcard.tsx
+++ b/src/components/study-flashcard/study-flashcard.tsx
@@ -1,7 +1,7 @@
 import React, { ReactNode } from 'react';
 import { AnimatePresence, motion } from 'framer-motion';
-import { noop } from '../../helpers/func';
-import { FlipTile } from '../flip-tile/flip-tile';
+import { FlipTile } from '@/components/flip-tile/flip-tile';
+import { noop } from '@/helpers/func';
 import './study-flashcard.scss';
 
 interface StudyFlashcardProps {

--- a/src/components/text-area/text-area.scss
+++ b/src/components/text-area/text-area.scss
@@ -1,6 +1,6 @@
 @import url('https://fonts.googleapis.com/css2?family=Comfortaa:wght@300;700&display=swap');
-@import '../../assets/colors';
-@import '../../assets/styles';
+@import '@/assets/colors';
+@import '@/assets/styles';
 
 // textarea also supports a 'col' attribute: 'col=20' => fit 20 characters per row
 // using this attribute would mean being able to remove `width: 100%` definitions in CSS

--- a/src/components/text-area/text-area.tsx
+++ b/src/components/text-area/text-area.tsx
@@ -1,6 +1,6 @@
 import React, { ChangeEvent, useState } from 'react';
-import { CopyIcon } from '../../assets/icons/copy-icon/copy-icon';
-import { ReactComponent as LockIcon } from '../../assets/svg/security-lock.svg';
+import { CopyIcon } from '@/assets/icons/copy-icon/copy-icon';
+import { ReactComponent as LockIcon } from '@/assets/svg/security-lock.svg';
 import './text-area.scss';
 
 export interface TextAreaProps {

--- a/src/components/text-box/text-box.scss
+++ b/src/components/text-box/text-box.scss
@@ -1,6 +1,6 @@
 @import url('https://fonts.googleapis.com/css2?family=Comfortaa:wght@300;700&display=swap');
-@import '../../assets/colors';
-@import '../../assets/styles';
+@import '@/assets/colors';
+@import '@/assets/styles';
 
 // component is light-theme by default
 $gap: 4px;

--- a/src/components/volume-control/volume-control.scss
+++ b/src/components/volume-control/volume-control.scss
@@ -1,5 +1,5 @@
-@import '../../../assets/colors';
-@import '../../../assets/styles';
+@import '@/assets/colors';
+@import '@/assets/styles';
 
 .c-volume-control {
   @include flex-center;

--- a/src/components/volume-control/volume-control.tsx
+++ b/src/components/volume-control/volume-control.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { SpeakerIcon } from '../../assets/icons/speaker-icon/speaker-icon';
-import { clamp } from '../../helpers/func';
+import { SpeakerIcon } from '@/assets/icons/speaker-icon/speaker-icon';
+import { clamp } from '@/helpers/func';
 import './volume-control.scss';
 
 interface VolumeControlProps {

--- a/src/helpers/tests/time.test.ts
+++ b/src/helpers/tests/time.test.ts
@@ -1,4 +1,4 @@
-import { getFormattedMilliseconds } from '../time';
+import { getFormattedMilliseconds } from '@/helpers/time';
 
 describe('getFormattedMilliseconds', () => {
   it('should return ~0:01 for times less than one second', () => {

--- a/src/helpers/tests/validator.test.ts
+++ b/src/helpers/tests/validator.test.ts
@@ -1,4 +1,4 @@
-import { isObject, objectSchemaSimple } from '../validator';
+import { isObject, objectSchemaSimple } from '@/helpers/validator';
 
 describe('validator', () => {
   it('should type-guard that subject is an object iff it is a js object', () => {

--- a/src/hooks/api/use-cards-client.ts
+++ b/src/hooks/api/use-cards-client.ts
@@ -1,8 +1,8 @@
+import { ECHOSTUDY_API_URL, ensureHttps } from '@/helpers/api';
+import { asUtcDate } from '@/helpers/time';
+import { Card, createNewCard } from '@/models/card';
+import { LazyAudio } from '@/models/lazy-audio';
 import { useFetchWrapper } from './use-fetch-wrapper';
-import { ECHOSTUDY_API_URL, ensureHttps } from '../../helpers/api';
-import { asUtcDate } from '../../helpers/time';
-import { Card, createNewCard } from '../../models/card';
-import { LazyAudio } from '../../models/lazy-audio';
 
 /* eslint-disable @typescript-eslint/no-unused-vars */
 

--- a/src/hooks/api/use-decks-client.ts
+++ b/src/hooks/api/use-decks-client.ts
@@ -1,7 +1,7 @@
+import { ECHOSTUDY_API_URL } from '@/helpers/api';
+import { asUtcDate } from '@/helpers/time';
+import { Deck } from '@/models/deck';
 import { useFetchWrapper } from './use-fetch-wrapper';
-import { ECHOSTUDY_API_URL } from '../../helpers/api';
-import { asUtcDate } from '../../helpers/time';
-import { Deck } from '../../models/deck';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/no-unused-vars */

--- a/src/hooks/api/use-fetch-wrapper.ts
+++ b/src/hooks/api/use-fetch-wrapper.ts
@@ -1,19 +1,13 @@
 import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useSetRecoilState } from 'recoil';
-import { ECHOSTUDY_API_URL } from '../../helpers/api';
-import { deferredPromise } from '../../helpers/promise';
-import { isDefined, objectSchemaSimple } from '../../helpers/validator';
-import { paths } from '../../routing/paths';
-import {
-  AuthJwt,
-  authJwtState,
-  authJwtToJson,
-  isAuthJwt,
-  jsonToAuthJwt,
-} from '../../state/auth-jwt';
-import { LocalStorageKeys } from '../../state/init';
-import { useLocalStorage } from '../use-local-storage';
+import { ECHOSTUDY_API_URL } from '@/helpers/api';
+import { deferredPromise } from '@/helpers/promise';
+import { isDefined, objectSchemaSimple } from '@/helpers/validator';
+import { useLocalStorage } from '@/hooks/use-local-storage';
+import { paths } from '@/routing/paths';
+import { AuthJwt, authJwtState, authJwtToJson, isAuthJwt, jsonToAuthJwt } from '@/state/auth-jwt';
+import { LocalStorageKeys } from '@/state/init';
 
 export interface FetchError {
   statusCode: number;

--- a/src/hooks/api/use-user-client.ts
+++ b/src/hooks/api/use-user-client.ts
@@ -1,25 +1,19 @@
 import { useNavigate } from 'react-router-dom';
 import { useRecoilState } from 'recoil';
 import { Md5 } from 'ts-md5';
-import { isFetchError, useFetchWrapper } from './use-fetch-wrapper';
-import { ECHOSTUDY_API_URL } from '../../helpers/api';
+import { ECHOSTUDY_API_URL } from '@/helpers/api';
+import { useLocalStorage } from '@/hooks/use-local-storage';
 import {
   IdentityError,
   isRegisterSuccess,
   RegisterSuccess,
   RegisterUserInfo,
   registerUserInfoToJson,
-} from '../../models/register-user';
-import { paths } from '../../routing/paths';
-import {
-  AuthJwt,
-  authJwtState,
-  authJwtToJson,
-  isAuthJwt,
-  jsonToAuthJwt,
-} from '../../state/auth-jwt';
-import { LocalStorageKeys } from '../../state/init';
-import { useLocalStorage } from '../use-local-storage';
+} from '@/models/register-user';
+import { paths } from '@/routing/paths';
+import { AuthJwt, authJwtState, authJwtToJson, isAuthJwt, jsonToAuthJwt } from '@/state/auth-jwt';
+import { LocalStorageKeys } from '@/state/init';
+import { isFetchError, useFetchWrapper } from './use-fetch-wrapper';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/no-unused-vars */

--- a/src/hooks/tests/use-fetch-wrapper.test.ts
+++ b/src/hooks/tests/use-fetch-wrapper.test.ts
@@ -1,7 +1,7 @@
 import { renderHook } from '@testing-library/react-hooks';
 import { enableFetchMocks } from 'jest-fetch-mock';
-import { withTestRoots } from '../../app.test';
-import { isFetchError, useFetchWrapper } from '../api/use-fetch-wrapper';
+import { withTestRoots } from '@/app.test';
+import { isFetchError, useFetchWrapper } from '@/hooks/api/use-fetch-wrapper';
 
 // provide fetchMock global and disable mocking initially
 enableFetchMocks();

--- a/src/hooks/tests/use-spaced-repetition.test.ts
+++ b/src/hooks/tests/use-spaced-repetition.test.ts
@@ -1,8 +1,8 @@
 import { renderHook } from '@testing-library/react-hooks';
-import { Card } from '../../models/card';
-import { getTestFoxCard, getTestMonkeyCard, getTestMouseCard } from '../../models/mock/card.mock';
-import { testEnglishDeck } from '../../models/mock/deck.mock';
-import { BoxStaleDays, scoreToBox, useSpacedRepetition } from '../use-spaced-repetition';
+import { BoxStaleDays, scoreToBox, useSpacedRepetition } from '@/hooks/use-spaced-repetition';
+import { Card } from '@/models/card';
+import { getTestFoxCard, getTestMonkeyCard, getTestMouseCard } from '@/models/mock/card.mock';
+import { testEnglishDeck } from '@/models/mock/deck.mock';
 
 describe('useSpacedRepetition', () => {
   const setup = () => {

--- a/src/hooks/tests/use-stop-watch.test.ts
+++ b/src/hooks/tests/use-stop-watch.test.ts
@@ -1,6 +1,6 @@
 import { act, renderHook } from '@testing-library/react-hooks';
-import { withFakeTimers } from '../../helpers/test';
-import { useStopWatch } from '../use-stop-watch';
+import { withFakeTimers } from '@/helpers/test';
+import { useStopWatch } from '@/hooks/use-stop-watch';
 
 describe('useStopWatch', () => {
   const setup = () => {

--- a/src/hooks/tests/use-timer.test.ts
+++ b/src/hooks/tests/use-timer.test.ts
@@ -1,6 +1,6 @@
 import { act, renderHook } from '@testing-library/react-hooks';
-import { withFakeTimers } from '../../helpers/test';
-import { useTimer } from '../use-timer';
+import { withFakeTimers } from '@/helpers/test';
+import { useTimer } from '@/hooks/use-timer';
 
 describe('useTimer', () => {
   let mockCallback: jest.Mock<void, []>;

--- a/src/hooks/use-deck-editor.ts
+++ b/src/hooks/use-deck-editor.ts
@@ -1,8 +1,8 @@
 import { useReducer, useState } from 'react';
+import { Card } from '@/models/card';
+import { Deck, DeckMetaData } from '@/models/deck';
 import { useCardsClient } from './api/use-cards-client';
 import { useDecksClient } from './api/use-decks-client';
-import { Card } from '../models/card';
-import { Deck, DeckMetaData } from '../models/deck';
 
 type CardMap = { [id: string]: Card };
 

--- a/src/hooks/use-lazy-audio-player.ts
+++ b/src/hooks/use-lazy-audio-player.ts
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { LazyAudio } from '../models/lazy-audio';
+import { LazyAudio } from '@/models/lazy-audio';
 
 export function useLazyAudioPlayer() {
   const [playingAudioFile, setPlayingAudioFile] = useState<LazyAudio>();

--- a/src/hooks/use-local-storage.ts
+++ b/src/hooks/use-local-storage.ts
@@ -1,4 +1,4 @@
-import { isObject, isString } from '../helpers/validator';
+import { isObject, isString } from '@/helpers/validator';
 
 /**
  * Provides a simple interface to browser local storage with added support for:

--- a/src/hooks/use-play-card-audio.ts
+++ b/src/hooks/use-play-card-audio.ts
@@ -1,11 +1,11 @@
 import { useEffect, useRef, useState } from 'react';
+import correctSound from '@/assets/sounds/correct.wav';
+import incorrectSound from '@/assets/sounds/incorrect.wav';
+import { LazyAudio } from '@/models/lazy-audio';
+import { LessonCard } from '@/models/lesson-card';
 import { useMountedRef } from './use-mounted-ref';
 import { useCaptureSpeech } from './use-speech-recognition';
 import { useTimer } from './use-timer';
-import correctSound from '../assets/sounds/correct.wav';
-import incorrectSound from '../assets/sounds/incorrect.wav';
-import { LazyAudio } from '../models/lazy-audio';
-import { LessonCard } from '../models/lesson-card';
 
 export function usePlayCardAudio() {
   // timer used to create wait periods between audios

--- a/src/hooks/use-play-lesson.ts
+++ b/src/hooks/use-play-lesson.ts
@@ -1,8 +1,8 @@
 import { useMemo, useState } from 'react';
+import { Deck } from '@/models/deck';
+import { createNewLessonCard, LessonCard } from '@/models/lesson-card';
 import { usePlayCardAudio } from './use-play-card-audio';
 import { useSpacedRepetition } from './use-spaced-repetition';
-import { Deck } from '../models/deck';
-import { createNewLessonCard, LessonCard } from '../models/lesson-card';
 
 // TODO: Add other lesson types
 type lessonType = 'review' | 'studyNew' | 'spacedRepetition';

--- a/src/hooks/use-spaced-repetition.ts
+++ b/src/hooks/use-spaced-repetition.ts
@@ -1,7 +1,7 @@
-import { compare, shuffle } from '../helpers/sort';
-import { daysBetween } from '../helpers/time';
-import { Card } from '../models/card';
-import { Deck } from '../models/deck';
+import { compare, shuffle } from '@/helpers/sort';
+import { daysBetween } from '@/helpers/time';
+import { Card } from '@/models/card';
+import { Deck } from '@/models/deck';
 
 /**
  * Provides an interface that takes a deck and outputs a series of cards fit for study.

--- a/src/hooks/use-speech-recognition.ts
+++ b/src/hooks/use-speech-recognition.ts
@@ -1,6 +1,6 @@
 import { useRef, useState } from 'react';
-import { CapturedSpeech } from '../models/captured-speech';
-import { DeckLanguage, getLanguageCode } from '../models/language';
+import { CapturedSpeech } from '@/models/captured-speech';
+import { DeckLanguage, getLanguageCode } from '@/models/language';
 
 export function useCaptureSpeech() {
   const speechRecognitionRef = useRef(getSpeechRecognitionObj());

--- a/src/layouts/already-authorized-layout/already-authorized-layout.tsx
+++ b/src/layouts/already-authorized-layout/already-authorized-layout.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { Navigate, Outlet } from 'react-router-dom';
 import { useRecoilValue } from 'recoil';
-import { paths } from '../../routing/paths';
-import { authJwtState } from '../../state/auth-jwt';
+import { paths } from '@/routing/paths';
+import { authJwtState } from '@/state/auth-jwt';
 
 // an inverse of the AuthorizedRoute
 export const AlreadyAuthorizedLayout = () => {

--- a/src/layouts/authorized-route-layout/authorized-route-layout.tsx
+++ b/src/layouts/authorized-route-layout/authorized-route-layout.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { Navigate, Outlet } from 'react-router-dom';
 import { useRecoilValue } from 'recoil';
-import { paths } from '../../routing/paths';
-import { authJwtState } from '../../state/auth-jwt';
+import { paths } from '@/routing/paths';
+import { authJwtState } from '@/state/auth-jwt';
 
 export const AuthorizedRouteLayout = () => {
   const authJwt = useRecoilValue(authJwtState);

--- a/src/layouts/full-screen-layout/full-screen-layout.scss
+++ b/src/layouts/full-screen-layout/full-screen-layout.scss
@@ -1,5 +1,5 @@
-@import '../../assets/colors';
-@import '../../assets/styles';
+@import '@/assets/colors';
+@import '@/assets/styles';
 
 .full-screen-layout-content {
   width: 100%;

--- a/src/layouts/sidebar-layout/sidebar-layout.scss
+++ b/src/layouts/sidebar-layout/sidebar-layout.scss
@@ -1,5 +1,5 @@
-@import '../../assets/colors';
-@import '../../assets/styles';
+@import '@/assets/colors';
+@import '@/assets/styles';
 
 // screen height without header
 $height-without-header: calc(100vh - #{$header-height});

--- a/src/layouts/sidebar-layout/sidebar-layout.tsx
+++ b/src/layouts/sidebar-layout/sidebar-layout.tsx
@@ -1,10 +1,10 @@
 import React, { useEffect } from 'react';
 import { Outlet } from 'react-router-dom';
 import { useRecoilState } from 'recoil';
-import { Header } from '../../components/header/header';
-import { Sidebar } from '../../components/sidebar/sidebar';
-import { throttle } from '../../helpers/func';
-import { navToggledState } from '../../state/nav';
+import { Header } from '@/components/header/header';
+import { Sidebar } from '@/components/sidebar/sidebar';
+import { throttle } from '@/helpers/func';
+import { navToggledState } from '@/state/nav';
 import './sidebar-layout.scss';
 
 export const SidebarLayout = () => {

--- a/src/models/mock/card-content.mock.ts
+++ b/src/models/mock/card-content.mock.ts
@@ -1,5 +1,5 @@
-import { CardContent, createNewCardContent } from '../card-content';
-import { LazyAudio } from '../lazy-audio';
+import { CardContent, createNewCardContent } from '@/models/card-content';
+import { LazyAudio } from '@/models/lazy-audio';
 
 export const getTestFoxFront = (): CardContent => {
   const content = createNewCardContent();

--- a/src/models/mock/card.mock.ts
+++ b/src/models/mock/card.mock.ts
@@ -1,3 +1,4 @@
+import { Card, createNewCard } from '@/models/card';
 import {
   getTestFoxBack,
   getTestFoxFront,
@@ -6,7 +7,6 @@ import {
   getTestMouseBack,
   getTestMouseFront,
 } from './card-content.mock';
-import { Card, createNewCard } from '../card';
 
 export const getTestFoxCard = (score?: number, dateTouched?: Date): Card => {
   const testCard = createNewCard();

--- a/src/models/mock/deck.mock.ts
+++ b/src/models/mock/deck.mock.ts
@@ -1,4 +1,4 @@
-import { Deck, DeckMetaData } from '../deck';
+import { Deck, DeckMetaData } from '@/models/deck';
 
 const mockDates = {
   dateCreated: new Date(),

--- a/src/models/register-user.ts
+++ b/src/models/register-user.ts
@@ -1,4 +1,4 @@
-import { objectSchemaSimple } from '../helpers/validator';
+import { objectSchemaSimple } from '@/helpers/validator';
 
 // for user registration requests
 export interface RegisterUserInfo {

--- a/src/pages/decks/flashcard-decks.scss
+++ b/src/pages/decks/flashcard-decks.scss
@@ -1,5 +1,5 @@
-@import '../../assets/colors';
-@import '../../assets/styles';
+@import '@/assets/colors';
+@import '@/assets/styles';
 
 .pg-flashcard-decks {
   display: flex;

--- a/src/pages/decks/flashcard-decks.tsx
+++ b/src/pages/decks/flashcard-decks.tsx
@@ -1,18 +1,18 @@
 import React, { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
-import { DeckCover } from '../../components/deck-cover/deck-cover';
-import { DropDown } from '../../components/drop-down/drop-down';
-import { noop } from '../../helpers/func';
-import { useDecksClient } from '../../hooks/api/use-decks-client';
-import { createNewDeck, Deck } from '../../models/deck';
-import { paths } from '../../routing/paths';
+import { DeckCover } from '@/components/deck-cover/deck-cover';
+import { DropDown } from '@/components/drop-down/drop-down';
+import { noop } from '@/helpers/func';
+import { useDecksClient } from '@/hooks/api/use-decks-client';
+import { createNewDeck, Deck } from '@/models/deck';
+import { paths } from '@/routing/paths';
 import {
   AllSortRules,
   userDecksSortedState,
   userDecksSortRuleState,
   userDecksState,
-} from '../../state/user-decks';
+} from '@/state/user-decks';
 import './flashcard-decks.scss';
 
 // (+ add new deck) and (all decks)

--- a/src/pages/edit-deck-page/deck-editor/deck-editor.scss
+++ b/src/pages/edit-deck-page/deck-editor/deck-editor.scss
@@ -1,5 +1,5 @@
-@import '../../../assets/colors';
-@import '../../../assets/styles';
+@import '@/assets/colors';
+@import '@/assets/styles';
 
 .deck-editor {
   .deck-editor-header {

--- a/src/pages/edit-deck-page/deck-editor/deck-editor.test.tsx
+++ b/src/pages/edit-deck-page/deck-editor/deck-editor.test.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { renderWithTestRoots } from '@/app.test';
+import { noop } from '@/helpers/func';
+import { createNewDeck } from '@/models/deck';
+import { testEnglishDeck } from '@/models/mock/deck.mock';
 import { DeckEditor } from './deck-editor';
-import { renderWithTestRoots } from '../../../app.test';
-import { noop } from '../../../helpers/func';
-import { createNewDeck } from '../../../models/deck';
-import { testEnglishDeck } from '../../../models/mock/deck.mock';
 
 jest.mock('../../../hooks/use-prompt');
 

--- a/src/pages/edit-deck-page/deck-editor/deck-editor.tsx
+++ b/src/pages/edit-deck-page/deck-editor/deck-editor.tsx
@@ -1,17 +1,17 @@
 import React, { useEffect, useState } from 'react';
 import { AnimatePresence } from 'framer-motion';
+import { Fade } from '@/animations/fade';
+import { UpToggle } from '@/animations/up-toggle';
+import { LoadingIcon } from '@/assets/icons/loading-icon/loading-icon';
+import { PlusIcon } from '@/assets/icons/plus-icon/plus-icon';
+import { Button } from '@/components/button/button';
+import { FlashcardSet } from '@/components/flashcard-set/flashcard-set';
+import { PageHeader } from '@/components/page-header/page-header';
+import { useDeckEditor } from '@/hooks/use-deck-editor';
+import { usePrompt } from '@/hooks/use-prompt';
+import { Card, createNewCard } from '@/models/card';
+import { Deck } from '@/models/deck';
 import { MetaDataEditor } from './meta-data-editor/meta-data-editor';
-import { Fade } from '../../../animations/fade';
-import { UpToggle } from '../../../animations/up-toggle';
-import { LoadingIcon } from '../../../assets/icons/loading-icon/loading-icon';
-import { PlusIcon } from '../../../assets/icons/plus-icon/plus-icon';
-import { Button } from '../../../components/button/button';
-import { FlashcardSet } from '../../../components/flashcard-set/flashcard-set';
-import { PageHeader } from '../../../components/page-header/page-header';
-import { useDeckEditor } from '../../../hooks/use-deck-editor';
-import { usePrompt } from '../../../hooks/use-prompt';
-import { Card, createNewCard } from '../../../models/card';
-import { Deck } from '../../../models/deck';
 import './deck-editor.scss';
 
 interface DeckEditorProps {

--- a/src/pages/edit-deck-page/deck-editor/meta-data-editor/meta-data-editor.scss
+++ b/src/pages/edit-deck-page/deck-editor/meta-data-editor/meta-data-editor.scss
@@ -1,5 +1,5 @@
-@import '../../../../assets/colors';
-@import '../../../../assets/styles';
+@import '@/assets/colors';
+@import '@/assets/styles';
 
 .deck-meta {
   .study-button {

--- a/src/pages/edit-deck-page/deck-editor/meta-data-editor/meta-data-editor.test.tsx
+++ b/src/pages/edit-deck-page/deck-editor/meta-data-editor/meta-data-editor.test.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { noop } from '@/helpers/func';
+import { testEnglishDeck } from '@/models/mock/deck.mock';
 import { MetaDataEditor } from './meta-data-editor';
-import { noop } from '../../../../helpers/func';
-import { testEnglishDeck } from '../../../../models/mock/deck.mock';
 
 describe('MetaDataEditor', () => {
   beforeEach(() => {

--- a/src/pages/edit-deck-page/deck-editor/meta-data-editor/meta-data-editor.tsx
+++ b/src/pages/edit-deck-page/deck-editor/meta-data-editor/meta-data-editor.tsx
@@ -1,18 +1,18 @@
 import React, { useState } from 'react';
-import { BubbleDivider } from '../../../../components/bubble-divider/bubble-divider';
-import { Button } from '../../../../components/button/button';
-import { LanguageDropDown } from '../../../../components/language-drop-down/drop-down-options/language-drop-down';
+import { BubbleDivider } from '@/components/bubble-divider/bubble-divider';
+import { Button } from '@/components/button/button';
+import { LanguageDropDown } from '@/components/language-drop-down/drop-down-options/language-drop-down';
 import {
   RadioButtonGroup,
   RadioButtonOption,
-} from '../../../../components/radio-button-group/radio-button-group';
-import { TextArea } from '../../../../components/text-area/text-area';
-import { TextBox } from '../../../../components/text-box/text-box';
-import { Card } from '../../../../models/card';
-import { Access, Deck, DeckMetaData } from '../../../../models/deck';
-import { AllDeckLanguages } from '../../../../models/language';
-import { ExportCardsPopup } from '../../../export-cards-popup/export-cards-popup';
-import { ImportCardsPopup } from '../../../import-cards-popup/import-cards-popup';
+} from '@/components/radio-button-group/radio-button-group';
+import { TextArea } from '@/components/text-area/text-area';
+import { TextBox } from '@/components/text-box/text-box';
+import { Card } from '@/models/card';
+import { Access, Deck, DeckMetaData } from '@/models/deck';
+import { AllDeckLanguages } from '@/models/language';
+import { ExportCardsPopup } from '@/pages/export-cards-popup/export-cards-popup';
+import { ImportCardsPopup } from '@/pages/import-cards-popup/import-cards-popup';
 import './meta-data-editor.scss';
 
 interface MetaDataEditorProps {

--- a/src/pages/edit-deck-page/deck-editor/meta-data-editor/popup-types.ts
+++ b/src/pages/edit-deck-page/deck-editor/meta-data-editor/popup-types.ts
@@ -1,4 +1,4 @@
-import { RadioButtonOption } from '../../../../components/radio-button-group/radio-button-group';
+import { RadioButtonOption } from '@/components/radio-button-group/radio-button-group';
 
 export type TermSeparator = ' ' | ',';
 export type CardSeparator = ';' | '\n';

--- a/src/pages/edit-deck-page/edit-deck-page.tsx
+++ b/src/pages/edit-deck-page/edit-deck-page.tsx
@@ -1,13 +1,13 @@
 import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { Fade } from '@/animations/fade';
+import { LoadingPage } from '@/components/loading-page/loading-page';
+import { isDefined } from '@/helpers/validator';
+import { useCardsClient } from '@/hooks/api/use-cards-client';
+import { useDecksClient } from '@/hooks/api/use-decks-client';
+import { Deck } from '@/models/deck';
+import { paths } from '@/routing/paths';
 import { DeckEditor } from './deck-editor/deck-editor';
-import { Fade } from '../../animations/fade';
-import { LoadingPage } from '../../components/loading-page/loading-page';
-import { isDefined } from '../../helpers/validator';
-import { useCardsClient } from '../../hooks/api/use-cards-client';
-import { useDecksClient } from '../../hooks/api/use-decks-client';
-import { Deck } from '../../models/deck';
-import { paths } from '../../routing/paths';
 import './edit-deck-page.scss';
 
 interface EditDeckPageProps {

--- a/src/pages/export-cards-popup/export-cards-popup.scss
+++ b/src/pages/export-cards-popup/export-cards-popup.scss
@@ -1,5 +1,5 @@
-@import '../../assets/colors';
-@import '../../assets/styles';
+@import '@/assets/colors';
+@import '@/assets/styles';
 
 .export-cards-popup-content {
   margin-top: 12px;

--- a/src/pages/export-cards-popup/export-cards-popup.tsx
+++ b/src/pages/export-cards-popup/export-cards-popup.tsx
@@ -1,16 +1,16 @@
 import React, { useEffect, useState } from 'react';
-import { BubbleDivider } from '../../components/bubble-divider/bubble-divider';
-import { Button } from '../../components/button/button';
-import { PopupModal } from '../../components/popup-modal/popup-modal';
-import { RadioButtonGroup } from '../../components/radio-button-group/radio-button-group';
-import { TextArea } from '../../components/text-area/text-area';
-import { Card } from '../../models/card';
+import { BubbleDivider } from '@/components/bubble-divider/bubble-divider';
+import { Button } from '@/components/button/button';
+import { PopupModal } from '@/components/popup-modal/popup-modal';
+import { RadioButtonGroup } from '@/components/radio-button-group/radio-button-group';
+import { TextArea } from '@/components/text-area/text-area';
+import { Card } from '@/models/card';
 import {
   CardSeparator,
   cardSeparatorOptions,
   termDefSeparatorOptions,
   TermSeparator,
-} from '../edit-deck-page/deck-editor/meta-data-editor/popup-types';
+} from '@/pages/edit-deck-page/deck-editor/meta-data-editor/popup-types';
 import './export-cards-popup.scss';
 
 interface ExportCardsPopupProps {

--- a/src/pages/import-cards-popup/import-cards-popup.scss
+++ b/src/pages/import-cards-popup/import-cards-popup.scss
@@ -1,5 +1,5 @@
-@import '../../assets/colors';
-@import '../../assets/styles';
+@import '@/assets/colors';
+@import '@/assets/styles';
 
 .import-cards-popup-content {
   margin-top: 12px;

--- a/src/pages/import-cards-popup/import-cards-popup.test.tsx
+++ b/src/pages/import-cards-popup/import-cards-popup.test.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { noop } from '@/helpers/func';
+import { Card } from '@/models/card';
 import { ImportCardsPopup } from './import-cards-popup';
-import { noop } from '../../helpers/func';
-import { Card } from '../../models/card';
 
 describe('ImportCardsPopup', () => {
   beforeEach(() => {

--- a/src/pages/import-cards-popup/import-cards-popup.tsx
+++ b/src/pages/import-cards-popup/import-cards-popup.tsx
@@ -1,19 +1,19 @@
 import React, { ReactNode, useState } from 'react';
-import { Button } from '../../components/button/button';
-import { FileInput, ImportedFile } from '../../components/file-input/file-input';
-import { PopupModal } from '../../components/popup-modal/popup-modal';
+import { Button } from '@/components/button/button';
+import { FileInput, ImportedFile } from '@/components/file-input/file-input';
+import { PopupModal } from '@/components/popup-modal/popup-modal';
 import {
   RadioButtonGroup,
   RadioButtonOption,
-} from '../../components/radio-button-group/radio-button-group';
-import { TextArea } from '../../components/text-area/text-area';
-import { Card, createNewCard } from '../../models/card';
+} from '@/components/radio-button-group/radio-button-group';
+import { TextArea } from '@/components/text-area/text-area';
+import { Card, createNewCard } from '@/models/card';
 import {
   CardSeparator,
   cardSeparatorOptions,
   termDefSeparatorOptions,
   TermSeparator,
-} from '../edit-deck-page/deck-editor/meta-data-editor/popup-types';
+} from '@/pages/edit-deck-page/deck-editor/meta-data-editor/popup-types';
 import './import-cards-popup.scss';
 
 type ImportMethod = 'FILE' | 'CLIPBOARD';

--- a/src/pages/landing-page/landing-page.scss
+++ b/src/pages/landing-page/landing-page.scss
@@ -1,5 +1,5 @@
-@import '../../assets/styles';
-@import '../../assets/colors';
+@import '@/assets/styles';
+@import '@/assets/colors';
 
 .landing-page {
   width: 100%;

--- a/src/pages/landing-page/landing-page.tsx
+++ b/src/pages/landing-page/landing-page.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
-import { Fade } from '../../animations/fade';
-import { ArrowIcon } from '../../assets/icons/arrow-icon/arrow-icon';
-import waveImage from '../../assets/images/wave.png';
-import { Button } from '../../components/button/button';
-import { Header } from '../../components/header/header';
-import { paths } from '../../routing/paths';
+import { Fade } from '@/animations/fade';
+import { ArrowIcon } from '@/assets/icons/arrow-icon/arrow-icon';
+import waveImage from '@/assets/images/wave.png';
+import { Button } from '@/components/button/button';
+import { Header } from '@/components/header/header';
+import { paths } from '@/routing/paths';
 import './landing-page.scss';
 
 const headerClassName = 'header-anchor';

--- a/src/pages/not-found-page/not-found-page.scss
+++ b/src/pages/not-found-page/not-found-page.scss
@@ -1,5 +1,5 @@
-@import '../../assets/styles';
-@import '../../assets/colors';
+@import '@/assets/styles';
+@import '@/assets/colors';
 
 .not-found-page {
   @include viewport-vertical-center;

--- a/src/pages/not-found-page/not-found-page.tsx
+++ b/src/pages/not-found-page/not-found-page.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import waveImage from '../../assets/images/wave.png';
-import { Header } from '../../components/header/header';
+import waveImage from '@/assets/images/wave.png';
+import { Header } from '@/components/header/header';
 import './not-found-page.scss';
 
 export const NotFoundPage = () => {

--- a/src/pages/profile-page/profile-page.scss
+++ b/src/pages/profile-page/profile-page.scss
@@ -1,5 +1,5 @@
-@import '../../assets/styles';
-@import '../../assets/colors';
+@import '@/assets/styles';
+@import '@/assets/colors';
 
 .pg-profile-page {
   padding-bottom: 64px;

--- a/src/pages/profile-page/profile-page.tsx
+++ b/src/pages/profile-page/profile-page.tsx
@@ -1,16 +1,16 @@
 import React, { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useRecoilValue, useSetRecoilState } from 'recoil';
-import { BubbleDivider } from '../../components/bubble-divider/bubble-divider';
-import { DeckCover } from '../../components/deck-cover/deck-cover';
-import { LoadingPage } from '../../components/loading-page/loading-page';
-import { PageHeader } from '../../components/page-header/page-header';
-import { useDecksClient } from '../../hooks/api/use-decks-client';
-import { useUserClient } from '../../hooks/api/use-user-client';
-import { Deck } from '../../models/deck';
-import { paths } from '../../routing/paths';
-import { userInfoStateAsync } from '../../state/auth-jwt';
-import { userDecksSortedState, userDecksState } from '../../state/user-decks';
+import { BubbleDivider } from '@/components/bubble-divider/bubble-divider';
+import { DeckCover } from '@/components/deck-cover/deck-cover';
+import { LoadingPage } from '@/components/loading-page/loading-page';
+import { PageHeader } from '@/components/page-header/page-header';
+import { useDecksClient } from '@/hooks/api/use-decks-client';
+import { useUserClient } from '@/hooks/api/use-user-client';
+import { Deck } from '@/models/deck';
+import { paths } from '@/routing/paths';
+import { userInfoStateAsync } from '@/state/auth-jwt';
+import { userDecksSortedState, userDecksState } from '@/state/user-decks';
 import './profile-page.scss';
 
 export const ProfilePage = () => {

--- a/src/pages/sign-in-page/sign-in-page.scss
+++ b/src/pages/sign-in-page/sign-in-page.scss
@@ -1,5 +1,5 @@
-@import '../../assets/colors';
-@import '../../assets/styles';
+@import '@/assets/colors';
+@import '@/assets/styles';
 
 .sign-in-panel {
   .field-container {

--- a/src/pages/sign-in-page/sign-in-page.tsx
+++ b/src/pages/sign-in-page/sign-in-page.tsx
@@ -1,10 +1,10 @@
 import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { RegistrationPanel } from '../../components/registration-panel/registration-panel';
-import { TextBox } from '../../components/text-box/text-box';
-import { isEmptyObject } from '../../helpers/validator';
-import { useUserClient } from '../../hooks/api/use-user-client';
-import { paths } from '../../routing/paths';
+import { RegistrationPanel } from '@/components/registration-panel/registration-panel';
+import { TextBox } from '@/components/text-box/text-box';
+import { isEmptyObject } from '@/helpers/validator';
+import { useUserClient } from '@/hooks/api/use-user-client';
+import { paths } from '@/routing/paths';
 import './sign-in-page.scss';
 
 interface SignInFormError {

--- a/src/pages/sign-up-page/sign-up-page.scss
+++ b/src/pages/sign-up-page/sign-up-page.scss
@@ -1,5 +1,5 @@
-@import '../../assets/colors';
-@import '../../assets/styles';
+@import '@/assets/colors';
+@import '@/assets/styles';
 
 .sign-up-panel {
   .field-container {

--- a/src/pages/sign-up-page/sign-up-page.tsx
+++ b/src/pages/sign-up-page/sign-up-page.tsx
@@ -1,11 +1,11 @@
 import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { RegistrationPanel } from '../../components/registration-panel/registration-panel';
-import { TextBox } from '../../components/text-box/text-box';
-import { isEmptyObject } from '../../helpers/validator';
-import { useUserClient } from '../../hooks/api/use-user-client';
-import { IdentityErrorCode } from '../../models/register-user';
-import { paths } from '../../routing/paths';
+import { RegistrationPanel } from '@/components/registration-panel/registration-panel';
+import { TextBox } from '@/components/text-box/text-box';
+import { isEmptyObject } from '@/helpers/validator';
+import { useUserClient } from '@/hooks/api/use-user-client';
+import { IdentityErrorCode } from '@/models/register-user';
+import { paths } from '@/routing/paths';
 import './sign-up-page.scss';
 
 interface SignUpFormError {

--- a/src/pages/study-page/study-lesson-page/study-lesson-page.scss
+++ b/src/pages/study-page/study-lesson-page/study-lesson-page.scss
@@ -1,5 +1,5 @@
-@import '../../../assets/colors';
-@import '../../../assets/styles';
+@import '@/assets/colors';
+@import '@/assets/styles';
 
 .study-lesson-page {
   .study-lesson-page-content {

--- a/src/pages/study-page/study-lesson-page/study-lesson-page.tsx
+++ b/src/pages/study-page/study-lesson-page/study-lesson-page.tsx
@@ -1,19 +1,19 @@
 import React, { useEffect, useState } from 'react';
 import { AnimatePresence } from 'framer-motion';
-import { Fade } from '../../../animations/fade';
-import { MicrophoneIcon } from '../../../assets/icons/microphone-icon/microphone-icon';
-import nextCardSound from '../../../assets/sounds/next-card.wav';
-import { AudioControlBar } from '../../../components/audio-control-bar/audio-control-bar';
-import { PageHeader } from '../../../components/page-header/page-header';
-import { ProgressBar } from '../../../components/progress-bar/progress-bar';
-import { StudyFlashcard } from '../../../components/study-flashcard/study-flashcard';
-import { noop } from '../../../helpers/func';
-import { useIsFirstRender } from '../../../hooks/use-is-first-render';
-import { usePlayLesson } from '../../../hooks/use-play-lesson';
-import { useStopWatch } from '../../../hooks/use-stop-watch';
-import { Deck } from '../../../models/deck';
-import { LazyAudio } from '../../../models/lazy-audio';
-import { LessonCard, LessonCardOutcome } from '../../../models/lesson-card';
+import { Fade } from '@/animations/fade';
+import { MicrophoneIcon } from '@/assets/icons/microphone-icon/microphone-icon';
+import nextCardSound from '@/assets/sounds/next-card.wav';
+import { AudioControlBar } from '@/components/audio-control-bar/audio-control-bar';
+import { PageHeader } from '@/components/page-header/page-header';
+import { ProgressBar } from '@/components/progress-bar/progress-bar';
+import { StudyFlashcard } from '@/components/study-flashcard/study-flashcard';
+import { noop } from '@/helpers/func';
+import { useIsFirstRender } from '@/hooks/use-is-first-render';
+import { usePlayLesson } from '@/hooks/use-play-lesson';
+import { useStopWatch } from '@/hooks/use-stop-watch';
+import { Deck } from '@/models/deck';
+import { LazyAudio } from '@/models/lazy-audio';
+import { LessonCard, LessonCardOutcome } from '@/models/lesson-card';
 import './study-lesson-page.scss';
 
 interface StudyPageLessonProps {

--- a/src/pages/study-page/study-page.scss
+++ b/src/pages/study-page/study-page.scss
@@ -1,2 +1,2 @@
-@import '../../assets/colors';
-@import '../../assets/styles';
+@import '@/assets/colors';
+@import '@/assets/styles';

--- a/src/pages/study-page/study-page.tsx
+++ b/src/pages/study-page/study-page.tsx
@@ -1,9 +1,9 @@
 import React, { useState } from 'react';
 import { AnimatePresence, motion } from 'framer-motion';
+import { Deck } from '@/models/deck';
+import { LessonCard } from '@/models/lesson-card';
 import { StudyLessonPage } from './study-lesson-page/study-lesson-page';
 import { StudyResultsPage } from './study-results-page/study-results-page';
-import { Deck } from '../../models/deck';
-import { LessonCard } from '../../models/lesson-card';
 import './study-page.scss';
 
 interface StudyPageProps {

--- a/src/pages/study-page/study-results-page/study-result-cards/study-result-cards.scss
+++ b/src/pages/study-page/study-results-page/study-result-cards/study-result-cards.scss
@@ -1,5 +1,5 @@
-@import '../../../../assets/colors';
-@import '../../../../assets/styles';
+@import '@/assets/colors';
+@import '@/assets/styles';
 
 .study-results-flashcard-container {
   @include flex-center;

--- a/src/pages/study-page/study-results-page/study-result-cards/study-result-cards.test.tsx
+++ b/src/pages/study-page/study-results-page/study-result-cards/study-result-cards.test.tsx
@@ -1,14 +1,10 @@
 import React, { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { noop } from '@/helpers/func';
+import { createNewDeck } from '@/models/deck';
+import { createNewLessonCard, LessonCard } from '@/models/lesson-card';
+import { getTestFoxCard, getTestMonkeyCard, getTestMouseCard } from '@/models/mock/card.mock';
 import { StudyResultCards } from './study-result-cards';
-import { noop } from '../../../../helpers/func';
-import { createNewDeck } from '../../../../models/deck';
-import { createNewLessonCard, LessonCard } from '../../../../models/lesson-card';
-import {
-  getTestFoxCard,
-  getTestMonkeyCard,
-  getTestMouseCard,
-} from '../../../../models/mock/card.mock';
 
 const MARK_AS_CORRECT_LABEL = 'mark as correct';
 const MARK_AS_INCORRECT_LABEL = 'mark as incorrect';

--- a/src/pages/study-page/study-results-page/study-result-cards/study-result-cards.tsx
+++ b/src/pages/study-page/study-results-page/study-result-cards/study-result-cards.tsx
@@ -1,15 +1,15 @@
 import React, { ReactNode, useState } from 'react';
-import { CorrectIcon } from '../../../../assets/icons/correct-icon/correct-icon';
-import { IncorrectIcon } from '../../../../assets/icons/incorrect-icon/incorrect-icon';
-import { SkippedIcon } from '../../../../assets/icons/skipped-icon/skipped-icon';
-import { DropDownOption } from '../../../../components/drop-down-options/drop-down-options';
-import { KebabMenu } from '../../../../components/kebab-menu/kebab-menu';
+import { CorrectIcon } from '@/assets/icons/correct-icon/correct-icon';
+import { IncorrectIcon } from '@/assets/icons/incorrect-icon/incorrect-icon';
+import { SkippedIcon } from '@/assets/icons/skipped-icon/skipped-icon';
+import { DropDownOption } from '@/components/drop-down-options/drop-down-options';
+import { KebabMenu } from '@/components/kebab-menu/kebab-menu';
 import {
   ReadOnlyFlashcard,
   ReadOnlyFlashcardVariant,
-} from '../../../../components/read-only-flashcard/read-only-flashcard';
-import { useLazyAudioPlayer } from '../../../../hooks/use-lazy-audio-player';
-import { LessonCard, LessonCardOutcome, LessonCardOutcomes } from '../../../../models/lesson-card';
+} from '@/components/read-only-flashcard/read-only-flashcard';
+import { useLazyAudioPlayer } from '@/hooks/use-lazy-audio-player';
+import { LessonCard, LessonCardOutcome, LessonCardOutcomes } from '@/models/lesson-card';
 import './study-result-cards.scss';
 
 interface StudyResultCardsProps {

--- a/src/pages/study-page/study-results-page/study-results-page.scss
+++ b/src/pages/study-page/study-results-page/study-results-page.scss
@@ -1,5 +1,5 @@
-@import '../../../assets/colors';
-@import '../../../assets/styles';
+@import '@/assets/colors';
+@import '@/assets/styles';
 
 .study-results-page {
   @include flex-center;

--- a/src/pages/study-page/study-results-page/study-results-page.tsx
+++ b/src/pages/study-page/study-results-page/study-results-page.tsx
@@ -1,20 +1,20 @@
 import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { UpToggle } from '@/animations/up-toggle';
+import { CardStackIcon } from '@/assets/icons/card-stack-icon/card-stack-icon';
+import { ClockIcon } from '@/assets/icons/clock-icon/clock-icon';
+import { LoadingIcon } from '@/assets/icons/loading-icon/loading-icon';
+import { StarIcon } from '@/assets/icons/star-icon/star-icon';
+import { BubbleDivider } from '@/components/bubble-divider/bubble-divider';
+import { Button } from '@/components/button/button';
+import { getFormattedMilliseconds } from '@/helpers/time';
+import { useCardsClient } from '@/hooks/api/use-cards-client';
+import { usePrompt } from '@/hooks/use-prompt';
+import { MAX_SCORE } from '@/hooks/use-spaced-repetition';
+import { Deck } from '@/models/deck';
+import { LessonCard } from '@/models/lesson-card';
+import { paths } from '@/routing/paths';
 import { StudyResultCards } from './study-result-cards/study-result-cards';
-import { UpToggle } from '../../../animations/up-toggle';
-import { CardStackIcon } from '../../../assets/icons/card-stack-icon/card-stack-icon';
-import { ClockIcon } from '../../../assets/icons/clock-icon/clock-icon';
-import { LoadingIcon } from '../../../assets/icons/loading-icon/loading-icon';
-import { StarIcon } from '../../../assets/icons/star-icon/star-icon';
-import { BubbleDivider } from '../../../components/bubble-divider/bubble-divider';
-import { Button } from '../../../components/button/button';
-import { getFormattedMilliseconds } from '../../../helpers/time';
-import { useCardsClient } from '../../../hooks/api/use-cards-client';
-import { usePrompt } from '../../../hooks/use-prompt';
-import { MAX_SCORE } from '../../../hooks/use-spaced-repetition';
-import { Deck } from '../../../models/deck';
-import { LessonCard } from '../../../models/lesson-card';
-import { paths } from '../../../routing/paths';
 import './study-results-page.scss';
 
 interface StudyResultsPageProps {

--- a/src/pages/view-deck-page/view-deck-page.scss
+++ b/src/pages/view-deck-page/view-deck-page.scss
@@ -1,5 +1,5 @@
-@import '../../assets/colors';
-@import '../../assets/styles';
+@import '@/assets/colors';
+@import '@/assets/styles';
 
 $flashcard-index-container-width: 45px;
 

--- a/src/pages/view-deck-page/view-deck-page.tsx
+++ b/src/pages/view-deck-page/view-deck-page.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
-import { Fade } from '../../animations/fade';
-import { Button } from '../../components/button/button';
-import { PageHeader } from '../../components/page-header/page-header';
-import { ReadOnlyFlashcard } from '../../components/read-only-flashcard/read-only-flashcard';
-import { getFormattedDate } from '../../helpers/time';
-import { useLazyAudioPlayer } from '../../hooks/use-lazy-audio-player';
-import { Deck } from '../../models/deck';
-import { paths } from '../../routing/paths';
+import { Fade } from '@/animations/fade';
+import { Button } from '@/components/button/button';
+import { PageHeader } from '@/components/page-header/page-header';
+import { ReadOnlyFlashcard } from '@/components/read-only-flashcard/read-only-flashcard';
+import { getFormattedDate } from '@/helpers/time';
+import { useLazyAudioPlayer } from '@/hooks/use-lazy-audio-player';
+import { Deck } from '@/models/deck';
+import { paths } from '@/routing/paths';
 import './view-deck-page.scss';
 
 interface ViewDeckPageProps {

--- a/src/routing/routes.tsx
+++ b/src/routing/routes.tsx
@@ -1,21 +1,21 @@
 import React from 'react';
 import { Route, Routes } from 'react-router-dom';
+import { loadDeck, ResourceLoader } from '@/components/resource-loader/resource-loader';
+import { AlreadyAuthorizedLayout } from '@/layouts/already-authorized-layout/already-authorized-layout';
+import { AuthorizedRouteLayout } from '@/layouts/authorized-route-layout/authorized-route-layout';
+import { FullscreenLayout } from '@/layouts/full-screen-layout/full-screen-layout';
+import { SidebarLayout } from '@/layouts/sidebar-layout/sidebar-layout';
+import { Deck } from '@/models/deck';
+import { FlashcardDecksPage } from '@/pages/decks/flashcard-decks';
+import { EditDeckPage } from '@/pages/edit-deck-page/edit-deck-page';
+import { LandingPage } from '@/pages/landing-page/landing-page';
+import { NotFoundPage } from '@/pages/not-found-page/not-found-page';
+import { ProfilePage } from '@/pages/profile-page/profile-page';
+import { SignInPage } from '@/pages/sign-in-page/sign-in-page';
+import { SignUpPage } from '@/pages/sign-up-page/sign-up-page';
+import { StudyPage } from '@/pages/study-page/study-page';
+import { ViewDeckPage } from '@/pages/view-deck-page/view-deck-page';
 import { paths } from './paths';
-import { loadDeck, ResourceLoader } from '../components/resource-loader/resource-loader';
-import { AlreadyAuthorizedLayout } from '../layouts/already-authorized-layout/already-authorized-layout';
-import { AuthorizedRouteLayout } from '../layouts/authorized-route-layout/authorized-route-layout';
-import { FullscreenLayout } from '../layouts/full-screen-layout/full-screen-layout';
-import { SidebarLayout } from '../layouts/sidebar-layout/sidebar-layout';
-import { Deck } from '../models/deck';
-import { FlashcardDecksPage } from '../pages/decks/flashcard-decks';
-import { EditDeckPage } from '../pages/edit-deck-page/edit-deck-page';
-import { LandingPage } from '../pages/landing-page/landing-page';
-import { NotFoundPage } from '../pages/not-found-page/not-found-page';
-import { ProfilePage } from '../pages/profile-page/profile-page';
-import { SignInPage } from '../pages/sign-in-page/sign-in-page';
-import { SignUpPage } from '../pages/sign-up-page/sign-up-page';
-import { StudyPage } from '../pages/study-page/study-page';
-import { ViewDeckPage } from '../pages/view-deck-page/view-deck-page';
 
 // sidebar navigation is in `./sidebar/sidebar-routes.tsx`
 // this component is to define all the possible routes for the app

--- a/src/state/auth-jwt.ts
+++ b/src/state/auth-jwt.ts
@@ -1,6 +1,6 @@
 import { atom, selector } from 'recoil';
-import { ECHOSTUDY_API_URL } from '../helpers/api';
-import { objectSchemaSimple } from '../helpers/validator';
+import { ECHOSTUDY_API_URL } from '@/helpers/api';
+import { objectSchemaSimple } from '@/helpers/validator';
 
 ///////////////
 /// AuthJwt ///

--- a/src/state/init.ts
+++ b/src/state/init.ts
@@ -1,6 +1,6 @@
 import { MutableSnapshot } from 'recoil';
+import { useLocalStorage } from '@/hooks/use-local-storage';
 import { AuthJwt, authJwtState } from './auth-jwt';
-import { useLocalStorage } from '../hooks/use-local-storage';
 
 export const enum LocalStorageKeys {
   'authJwt' = 'auth-jwt',

--- a/src/state/user-decks.ts
+++ b/src/state/user-decks.ts
@@ -1,6 +1,6 @@
 import { atom, selector } from 'recoil';
-import { compare, shuffle } from '../helpers/sort';
-import { Deck } from '../models/deck';
+import { compare, shuffle } from '@/helpers/sort';
+import { Deck } from '@/models/deck';
 
 export const AllSortRules = [
   'sequential',

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,11 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    }
   },
   "include": [
     "src"


### PR DESCRIPTION
## note: rebase on main after `add-export-cards-popup` merges

reviewing is probably easiest with a commit-by-commit basis

purely a code style change, we now always prefer `@/...` over parent imports `../../...`
because honestly, the relative parent paths were getting way too long
* the way this works is that `@/...` is an alias for the absolute path `src/...`

this is also applied for our scss files, we won't have any ambiguity over the relative path,
we can just stick `@import '@/assets/styles'` and we're guaranteed for it to work