### PR TITLE
fix: improve endpoint robustness

### DIFF
--- a/src/components/header/account-popup/account-popup.scss
+++ b/src/components/header/account-popup/account-popup.scss
@@ -31,6 +31,10 @@ $bg-opacity: 0; // opacity to set background if modal is open
   background: $white;
   border-radius: $standard-radius * 0.75;
 
+  &.fixed {
+    position: fixed;
+  }
+
   @media screen and (max-width: $small-screen) {
     right: 0;
   }

--- a/src/components/header/account-popup/account-popup.tsx
+++ b/src/components/header/account-popup/account-popup.tsx
@@ -1,7 +1,5 @@
 import React, { useRef } from 'react';
 import ReactDOM from 'react-dom';
-import { CancelIcon } from '@/assets/icons/cancel-icon/cancel-icon';
-import { useFocusFirst } from '@/hooks/use-focus-first';
 import { useFocusTrap } from '@/hooks/use-focus-trap';
 import { useEscapePress } from '@/hooks/use-key-press';
 import { useOutsideClick } from '@/hooks/use-outside-click';
@@ -9,6 +7,7 @@ import './account-popup.scss';
 
 export interface AccountPopupProps {
   className?: string;
+  fixed?: boolean;
   children: React.ReactNode;
   showTrigger: boolean;
   onClose: () => void;
@@ -16,6 +15,7 @@ export interface AccountPopupProps {
 
 export const AccountPopup = ({
   className = '',
+  fixed = false,
   children,
   showTrigger,
   onClose,
@@ -27,12 +27,13 @@ export const AccountPopup = ({
   useEscapePress(() => onClose(), showTrigger);
 
   const showClass = showTrigger ? 'visible' : 'hidden';
+  const fixedClass = fixed ? 'fixed' : '';
 
   // render onto <div id="portal"></div> instead of in parent hierarchy but still propagate events
   return ReactDOM.createPortal(
     <>
       <div className={`c-account-popup-overlay ${showClass}`}>
-        <div className={`c-account-popup-content ${className}`} ref={contentRef}>
+        <div className={`c-account-popup-content ${className} ${fixedClass}`} ref={contentRef}>
           {children}
         </div>
       </div>

--- a/src/components/header/header.tsx
+++ b/src/components/header/header.tsx
@@ -94,7 +94,13 @@ export const Header = ({
 
   function getAccountButtons() {
     if (isAuthJwt(authJwt)) {
-      return <WelcomeUser onProfileClick={handleProfileClick} onLogoutClick={handleLogoutClick} />;
+      return (
+        <WelcomeUser
+          fixed={fixed}
+          onProfileClick={handleProfileClick}
+          onLogoutClick={handleLogoutClick}
+        />
+      );
     } else {
       return (
         <>

--- a/src/components/header/welcome-user/welcome-user.tsx
+++ b/src/components/header/welcome-user/welcome-user.tsx
@@ -8,6 +8,7 @@ import './welcome-user.scss';
 
 interface WelcomeUserProps {
   className?: string;
+  fixed?: boolean;
   onProfileClick?: (event: React.MouseEvent) => void;
   onLogoutClick?: (event: React.MouseEvent) => void;
 }
@@ -20,7 +21,12 @@ export const WelcomeUser = (props: WelcomeUserProps) => {
   );
 };
 
-const AsyncWelcomeUser = ({ className = '', onProfileClick, onLogoutClick }: WelcomeUserProps) => {
+const AsyncWelcomeUser = ({
+  className = '',
+  fixed = false,
+  onProfileClick,
+  onLogoutClick,
+}: WelcomeUserProps) => {
   const userData = useRecoilValue(userInfoStateAsync);
   const userClient = useUserClient();
   const pfpUrl = userClient.getProfilePictureUrl(userData?.email ?? '');
@@ -38,6 +44,7 @@ const AsyncWelcomeUser = ({ className = '', onProfileClick, onLogoutClick }: Wel
       </div>
       <AccountPopup
         className={`welcome-account-popup ${className}`}
+        fixed={fixed}
         showTrigger={showPopup}
         onClose={() => setShowPopup(false)}
       >

--- a/src/helpers/validator.ts
+++ b/src/helpers/validator.ts
@@ -38,3 +38,7 @@ export function isEmptyObject(subject: unknown): subject is Record<string, never
 export function isString(subject: unknown): subject is string {
   return typeof subject === 'string';
 }
+
+export function isBlankString(subject: unknown): subject is '' {
+  return isString(subject) && subject === '';
+}

--- a/src/helpers/validator.ts
+++ b/src/helpers/validator.ts
@@ -42,3 +42,7 @@ export function isString(subject: unknown): subject is string {
 export function isBlankString(subject: unknown): subject is '' {
   return isString(subject) && subject === '';
 }
+
+export function isNumber(subject: unknown): subject is number {
+  return typeof subject === 'number';
+}

--- a/src/hooks/api/interfaces/card-data.ts
+++ b/src/hooks/api/interfaces/card-data.ts
@@ -1,0 +1,9 @@
+export interface UpdateCardScoreRequest {
+  id: number;
+  score: number;
+}
+
+export interface NewCardsResponse {
+  ids: number[];
+  dateCreated: Date; // shared for all created cards
+}

--- a/src/hooks/api/interfaces/deck-data.ts
+++ b/src/hooks/api/interfaces/deck-data.ts
@@ -1,0 +1,4 @@
+export interface NewDecksResponse {
+  ids: number[];
+  dateCreated: Date; // shared for all created cards
+}

--- a/src/hooks/api/use-cards-client.ts
+++ b/src/hooks/api/use-cards-client.ts
@@ -2,6 +2,7 @@ import { ECHOSTUDY_API_URL, ensureHttps } from '@/helpers/api';
 import { asUtcDate } from '@/helpers/time';
 import { Card, createNewCard } from '@/models/card';
 import { LazyAudio } from '@/models/lazy-audio';
+import { NewCardsResponse, UpdateCardScoreRequest } from './interfaces/card-data';
 import { useFetchWrapper } from './use-fetch-wrapper';
 
 /* eslint-disable @typescript-eslint/no-unused-vars */
@@ -25,7 +26,7 @@ export function useCardsClient() {
     addCards,
     updateCardById,
     updateCardsById,
-    updateCardScoreById,
+    updateCardScores,
 
     // removals
     deleteCard,
@@ -70,15 +71,15 @@ export function useCardsClient() {
   //////////////////////
 
   // POST: /Cards
-  async function addCard(card: Card, deckId: number): Promise<number> {
-    const { id } = await fetchWrapper.post('/Cards', cardToJson(card, deckId));
-    return id;
+  async function addCard(card: Card, deckId: number): Promise<NewCardsResponse> {
+    return addCards([card], deckId);
   }
 
-  // POST: /Cards
-  // Todo: Add batching
-  async function addCards(cards: Card[], deckId: number): Promise<number[]> {
-    return Promise.all(cards.map((card) => addCard(card, deckId)));
+  // POST: /Cards (batching)
+  async function addCards(cards: Card[], deckId: number): Promise<NewCardsResponse> {
+    const cardsToAdd = cards.map((card) => cardToJson(card, deckId));
+    const response = await fetchWrapper.post('/Cards', cardsToAdd);
+    return response;
   }
 
   // POST: /Cards/{id}
@@ -95,9 +96,8 @@ export function useCardsClient() {
   }
 
   // POST: /Cards/Study
-  async function updateCardScoreById(id: number, score: number): Promise<void> {
-    const requestBody = { id: id, score: score };
-    return fetchWrapper.post('/Cards/Study', requestBody);
+  async function updateCardScores(cardScores: UpdateCardScoreRequest[]): Promise<void> {
+    return fetchWrapper.post('/Cards/Study', cardScores);
   }
 
   /////////////////

--- a/src/hooks/api/use-cards-client.ts
+++ b/src/hooks/api/use-cards-client.ts
@@ -25,8 +25,8 @@ export function useCardsClient() {
     // adds & updates
     addCard,
     addCards,
-    updateCardById,
-    updateCardsById,
+    updateCard,
+    updateCards,
     updateCardScores,
 
     // removals
@@ -81,13 +81,13 @@ export function useCardsClient() {
   }
 
   // POST: /Cards/Update
-  async function updateCardById(card: Card): Promise<NewCardsResponse> {
+  async function updateCard(card: Card): Promise<NewCardsResponse> {
     assertIdIsNumber(card.id);
-    return updateCardsById([card]);
+    return updateCards([card]);
   }
 
   // POST: /Cards/Update
-  async function updateCardsById(cards: Card[]): Promise<NewCardsResponse> {
+  async function updateCards(cards: Card[]): Promise<NewCardsResponse> {
     cards.forEach((card) => assertIdIsNumber(card.id));
 
     const cardsToUpdate = cards.map((card) => cardToJson(card));

--- a/src/hooks/api/use-decks-client.ts
+++ b/src/hooks/api/use-decks-client.ts
@@ -1,6 +1,7 @@
 import { ECHOSTUDY_API_URL } from '@/helpers/api';
 import { asUtcDate } from '@/helpers/time';
 import { Deck } from '@/models/deck';
+import { NewDecksResponse } from './interfaces/deck-data';
 import { useFetchWrapper } from './use-fetch-wrapper';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
@@ -74,9 +75,9 @@ export function useDecksClient() {
   //////////////////////
 
   // POST: /Decks
-  async function addDeck(deck: Deck): Promise<number> {
-    const { id } = await fetchWrapper.post('/Decks', deckToJson(deck));
-    return id;
+  async function addDeck(deck: Deck): Promise<NewDecksResponse> {
+    const response = await fetchWrapper.post('/Decks', [deckToJson(deck)]);
+    return response;
   }
 
   // POST: /Decks/{id}

--- a/src/hooks/use-deck-editor.ts
+++ b/src/hooks/use-deck-editor.ts
@@ -64,13 +64,16 @@ export const useDeckEditor = (deck: Deck): DeckEditorReturn => {
     setIsSaving(true);
     try {
       const deckId = state.currentDeck.metaData.id;
+      const addedCards = Object.values(state.addedCards).filter(filterBlankCards);
+      const updatedCards = Object.values(state.updatedCards).filter(filterBlankCards);
+      const deletedCards = Object.values(state.deletedCards);
+
       const promises = [
         decksClient.updateDeckById(state.currentDeck),
-        cardsClient.addCards(Object.values(state.addedCards).filter(filterBlankCards), deckId),
-        cardsClient.updateCardsById(Object.values(state.updatedCards).filter(filterBlankCards)),
-        cardsClient.deleteCards(Object.values(state.deletedCards)),
+        ...[addedCards.length > 0 ? cardsClient.addCards(addedCards, deckId) : []],
+        ...[updatedCards.length > 0 ? cardsClient.updateCards(updatedCards) : []],
+        ...[deletedCards.length > 0 ? cardsClient.deleteCards(deletedCards) : []],
         // Todo: we need to send the reordered cards too
-        // Todo: add batching (for update and delete cards)
       ];
       await Promise.all(promises);
       dispatch({ type: DECK_REDUCER_TYPE.SET_DECK, newDeck: state.currentDeck });

--- a/src/hooks/use-deck-editor.ts
+++ b/src/hooks/use-deck-editor.ts
@@ -70,7 +70,7 @@ export const useDeckEditor = (deck: Deck): DeckEditorReturn => {
         cardsClient.updateCardsById(Object.values(state.updatedCards)),
         cardsClient.deleteCards(Object.values(state.deletedCards)),
         // Todo: we need to send the reordered cards too
-        // Todo: add batching
+        // Todo: add batching (for update and delete cards)
       ];
       await Promise.all(promises);
       dispatch({ type: DECK_REDUCER_TYPE.SET_DECK, newDeck: state.currentDeck });

--- a/src/hooks/use-deck-editor.ts
+++ b/src/hooks/use-deck-editor.ts
@@ -67,7 +67,7 @@ export const useDeckEditor = (deck: Deck): DeckEditorReturn => {
       const promises = [
         decksClient.updateDeckById(state.currentDeck),
         cardsClient.addCards(Object.values(state.addedCards).filter(filterBlankCards), deckId),
-        cardsClient.updateCardsById(Object.values(state.updatedCards)),
+        cardsClient.updateCardsById(Object.values(state.updatedCards).filter(filterBlankCards)),
         cardsClient.deleteCards(Object.values(state.deletedCards)),
         // Todo: we need to send the reordered cards too
         // Todo: add batching (for update and delete cards)

--- a/src/hooks/use-deck-editor.ts
+++ b/src/hooks/use-deck-editor.ts
@@ -1,5 +1,5 @@
 import { useReducer, useState } from 'react';
-import { Card } from '@/models/card';
+import { Card, filterBlankCards } from '@/models/card';
 import { Deck, DeckMetaData } from '@/models/deck';
 import { useCardsClient } from './api/use-cards-client';
 import { useDecksClient } from './api/use-decks-client';
@@ -66,7 +66,7 @@ export const useDeckEditor = (deck: Deck): DeckEditorReturn => {
       const deckId = state.currentDeck.metaData.id;
       const promises = [
         decksClient.updateDeckById(state.currentDeck),
-        cardsClient.addCards(Object.values(state.addedCards), deckId),
+        cardsClient.addCards(Object.values(state.addedCards).filter(filterBlankCards), deckId),
         cardsClient.updateCardsById(Object.values(state.updatedCards)),
         cardsClient.deleteCards(Object.values(state.deletedCards)),
         // Todo: we need to send the reordered cards too

--- a/src/models/card.ts
+++ b/src/models/card.ts
@@ -1,4 +1,5 @@
 import { v4 as uuidv4 } from 'uuid';
+import { isBlankString } from '@/helpers/validator';
 import { CardContent, createNewCardContent } from './card-content';
 export interface Card {
   id?: number;
@@ -22,4 +23,8 @@ export function createNewCard(): Card {
     dateUpdated: new Date(),
     dateTouched: new Date(),
   };
+}
+
+export function filterBlankCards(card: Card) {
+  return !isBlankString(card.front.text) && !isBlankString(card.back.text);
 }

--- a/src/pages/edit-deck-page/edit-deck-page.tsx
+++ b/src/pages/edit-deck-page/edit-deck-page.tsx
@@ -5,6 +5,7 @@ import { LoadingPage } from '@/components/loading-page/loading-page';
 import { isDefined } from '@/helpers/validator';
 import { useCardsClient } from '@/hooks/api/use-cards-client';
 import { useDecksClient } from '@/hooks/api/use-decks-client';
+import { filterBlankCards } from '@/models/card';
 import { Deck } from '@/models/deck';
 import { paths } from '@/routing/paths';
 import { DeckEditor } from './deck-editor/deck-editor';
@@ -46,7 +47,7 @@ export const EditDeckPage = ({ deck }: EditDeckPageProps) => {
   async function handleCreateDeckClick(deck: Deck) {
     return _withLoadingUntilResolved('Creating your new deck...', async () => {
       const newDeckId = await addDeck(deck);
-      await addCards(deck.cards, newDeckId);
+      await addCards(deck.cards.filter(filterBlankCards), newDeckId);
       navigateToViewDeck(newDeckId);
     });
   }

--- a/src/pages/edit-deck-page/edit-deck-page.tsx
+++ b/src/pages/edit-deck-page/edit-deck-page.tsx
@@ -18,7 +18,7 @@ interface EditDeckPageProps {
 export const EditDeckPage = ({ deck }: EditDeckPageProps) => {
   const navigate = useNavigate();
   const { deleteDeckById, addDeck } = useDecksClient();
-  const { addCards } = useCardsClient();
+  const cardsClient = useCardsClient();
 
   // when this is not undefined, show a loading animation for long-running operations
   const [loadingLabel, setLoadingLabel] = useState<string | undefined>();
@@ -46,8 +46,11 @@ export const EditDeckPage = ({ deck }: EditDeckPageProps) => {
 
   async function handleCreateDeckClick(deck: Deck) {
     return _withLoadingUntilResolved('Creating your new deck...', async () => {
-      const newDeckId = await addDeck(deck);
-      await addCards(deck.cards.filter(filterBlankCards), newDeckId);
+      const deckResponse = await addDeck(deck);
+      const newDeckId = deckResponse.ids[0];
+
+      const cardsWithContent = deck.cards.filter(filterBlankCards);
+      await cardsClient.addCards(cardsWithContent, newDeckId);
       navigateToViewDeck(newDeckId);
     });
   }

--- a/src/pages/export-cards-popup/export-cards-popup.tsx
+++ b/src/pages/export-cards-popup/export-cards-popup.tsx
@@ -99,7 +99,7 @@ export const ExportCardsPopup = ({ title, cards, showPopup, onClose }: ExportCar
       .replace('T', '-');
 
     element.href = URL.createObjectURL(file);
-    element.download = safeTitle + '-' + safeDate;
+    element.download = safeTitle + '-' + safeDate + '.txt';
     document.body.appendChild(element); // required to work in Firefox
 
     element.click();

--- a/src/pages/study-page/study-results-page/study-results-page.tsx
+++ b/src/pages/study-page/study-results-page/study-results-page.tsx
@@ -8,6 +8,7 @@ import { StarIcon } from '@/assets/icons/star-icon/star-icon';
 import { BubbleDivider } from '@/components/bubble-divider/bubble-divider';
 import { Button } from '@/components/button/button';
 import { getFormattedMilliseconds } from '@/helpers/time';
+import { UpdateCardScoreRequest } from '@/hooks/api/interfaces/card-data';
 import { useCardsClient } from '@/hooks/api/use-cards-client';
 import { usePrompt } from '@/hooks/use-prompt';
 import { MAX_SCORE } from '@/hooks/use-spaced-repetition';
@@ -133,14 +134,12 @@ export const StudyResultsPage = ({
     setAreResultsApplied(true);
   }
 
-  // TODO: it might be beneficial to have an endpoint to batch these (an array of {id, score})
-  // we are currently making requests equal to the number of seen lesson cards (marked correct/incorrect)
   async function _updateAllCardScores() {
     if (isUpdating) {
       return;
     }
 
-    const promises = [];
+    const scoreUpdates: UpdateCardScoreRequest[] = [];
 
     // create promise to update cards with new scores
     for (const lessonCard of lessonCards) {
@@ -155,12 +154,12 @@ export const StudyResultsPage = ({
       }
 
       if (lessonCard.id) {
-        promises.push(cardsClient.updateCardScoreById(lessonCard.id, newScore));
+        scoreUpdates.push({ id: lessonCard.id, score: newScore });
       } else {
         throw new Error(`Failed to update lesson card: id was undefined`); // this shouldn't be possible...
       }
     }
 
-    return Promise.all(promises);
+    return cardsClient.updateCardScores(scoreUpdates);
   }
 };


### PR DESCRIPTION
- prevent empty cards (both front & back empty) from being added/saved
- use the new batch endpoints for deck create, card edit/score update/create/delete
- prevent deck editor from sending empty requests (e.g. no cards deleted should avoid doing `Cards/Delete`)
- make account popup fixed when header is also fixed