### PR TITLE
fix: text overflow improvements and save button state

### DIFF
--- a/src/assets/_styles.scss
+++ b/src/assets/_styles.scss
@@ -56,6 +56,14 @@ $z-popup-modal: 1024;
   align-items: center;
 }
 
+// can be useful for safely centering items that would otherwise overflow a container
+// if it would overflow, the top-edge is inline with the top of the parent container
+// for an example, see: https://codepen.io/jiejasonliu/pen/wvXwdRb
+@mixin grid-center {
+  display: grid;
+  place-items: center;
+}
+
 @mixin viewport-vertical-center {
   margin-top: 50vh; // could be padding-top: 100vh, but we'll see
   transform: translate(0, -50%);

--- a/src/assets/_styles.scss
+++ b/src/assets/_styles.scss
@@ -71,6 +71,14 @@ $z-popup-modal: 1024;
   text-overflow: ellipsis;
 }
 
+@mixin multiline-ellipsis-overflow($lines) {
+  display: -webkit-box;
+  -webkit-line-clamp: $lines;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 @mixin floating-card {
   @include box-shadow;
   position: absolute;

--- a/src/components/deck-cover/deck-cover.scss
+++ b/src/components/deck-cover/deck-cover.scss
@@ -5,10 +5,17 @@
   margin: 10px;
 
   .cover-front {
-    @include flex-center;
+    display: grid;
+    place-items: center;
+    padding: 16px;
+
     background-color: $deck-cover-blue;
     color: $white;
     font-size: 30px;
+
+    div.c-front-inner {
+      @include multiline-ellipsis-overflow(4);
+    }
   }
 
   .cover-back {
@@ -18,10 +25,14 @@
     padding: 15px;
 
     label {
+      @include multiline-ellipsis-overflow(2);
       font-size: 20px;
     }
 
     p {
+      @include webkit-scrollbar;
+      width: 100%;
+      word-break: break-all;
       overflow-y: auto; // only show vertical scroll when needed
       font-size: 12px;
       flex: 1;

--- a/src/components/deck-cover/deck-cover.scss
+++ b/src/components/deck-cover/deck-cover.scss
@@ -5,8 +5,7 @@
   margin: 10px;
 
   .cover-front {
-    display: grid;
-    place-items: center;
+    @include grid-center;
     padding: 16px;
 
     background-color: $deck-cover-blue;

--- a/src/components/flip-tile/flip-tile.tsx
+++ b/src/components/flip-tile/flip-tile.tsx
@@ -29,7 +29,9 @@ export const FlipTile = ({
     <div className={`c-flip-tile ${className}`} onClick={onClick}>
       <div className={`c-card ${isFlipped ? 'is-flipped' : ''}`}>
         <div className="c-front">
-          <div className={`tile-content ${frontClassName}`}>{front}</div>
+          <div className={`tile-content ${frontClassName}`}>
+            <div className="c-front-inner">{front}</div>
+          </div>
         </div>
         <div className="c-back">
           <div className={`tile-content ${backClassName}`}>{back}</div>

--- a/src/components/popup-modal/popup-modal.scss
+++ b/src/components/popup-modal/popup-modal.scss
@@ -48,6 +48,10 @@ $y-axis: 25%; // where to place popup on y-axis
     font-size: 20px;
 
     @media screen and (min-width: $large-screen) {
+      max-width: 30vw;
+    }
+
+    @media screen and (min-width: $giant-screen) {
       max-width: 25vw;
     }
   }

--- a/src/components/popup-modal/popup-modal.scss
+++ b/src/components/popup-modal/popup-modal.scss
@@ -40,9 +40,20 @@ $y-axis: 25%; // where to place popup on y-axis
     display: flex;
     justify-content: space-between;
     align-items: center;
+    gap: 8px;
+
     color: $blue;
     font-family: 'Comfortaa';
     font-weight: bold;
     font-size: 20px;
+
+    @media screen and (min-width: $large-screen) {
+      max-width: 25vw;
+    }
+  }
+
+  .c-popup-modal-cancel-icon {
+    flex-shrink: 0;
+    align-self: flex-start;
   }
 }

--- a/src/components/popup-modal/popup-modal.tsx
+++ b/src/components/popup-modal/popup-modal.tsx
@@ -39,7 +39,7 @@ export const PopupModal = ({
         <div className="c-popup-modal-content" ref={contentRef}>
           <div className="c-popup-modal-header">
             <span>{headerLabel}</span>
-            <CancelIcon variant="dark" onClick={onClose} />
+            <CancelIcon className="c-popup-modal-cancel-icon" variant="dark" onClick={onClose} />
           </div>
           {children}
         </div>

--- a/src/components/study-flashcard/study-flashcard.scss
+++ b/src/components/study-flashcard/study-flashcard.scss
@@ -12,11 +12,7 @@
   }
 
   .c-study-flashcard-content {
-    @include webkit-scrollbar;
-    display: grid;
-    place-items: center;
-    overflow-y: auto;
-
+    @include grid-center;
     width: 100%;
     height: 100%;
     border-radius: 15px;
@@ -30,6 +26,14 @@
       font-size: 20px;
       top: 10px;
       left: 10px;
+    }
+
+    .c-study-flashcard-text {
+      @include webkit-scrollbar;
+      @include grid-center;
+      overflow-y: auto;
+      width: 100%;
+      height: 100%;
     }
   }
 

--- a/src/components/study-flashcard/study-flashcard.scss
+++ b/src/components/study-flashcard/study-flashcard.scss
@@ -6,22 +6,31 @@
   margin: 10px;
   font-size: 40px;
 
+  .study-card-front div.c-front-inner {
+    height: 100%;
+    width: 100%;
+  }
+
   .c-study-flashcard-content {
-    @include flex-center;
+    @include webkit-scrollbar;
+    display: grid;
+    place-items: center;
+    overflow-y: auto;
+
     width: 100%;
     height: 100%;
     border-radius: 15px;
     text-align: center;
     padding: 20px;
     box-sizing: border-box;
-  }
 
-  .c-study-flashcard-side-label {
-    position: absolute;
-    display: inline-block;
-    font-size: 20px;
-    top: 10px;
-    left: 10px;
+    .c-study-flashcard-side-label {
+      position: absolute;
+      display: inline-block;
+      font-size: 20px;
+      top: 10px;
+      left: 10px;
+    }
   }
 
   .dark {

--- a/src/components/study-flashcard/study-flashcard.tsx
+++ b/src/components/study-flashcard/study-flashcard.tsx
@@ -51,7 +51,7 @@ export const StudyFlashcard = ({
     return (
       <div className={`c-study-flashcard-content  ${variant} ${cardFaceClass}`}>
         <label className="c-study-flashcard-side-label">{label}</label>
-        {content}
+        <div className="c-study-flashcard-text">{content}</div>
       </div>
     );
   }

--- a/src/components/study-flashcard/study-flashcard.tsx
+++ b/src/components/study-flashcard/study-flashcard.tsx
@@ -39,7 +39,7 @@ export const StudyFlashcard = ({
           className="study-card"
           isFlipped={activeSide !== 'front'}
           front={getCardFace(frontContent, frontLabel)}
-          frontClassName={'dark'}
+          frontClassName={'study-card-front dark'}
           back={getCardFace(backContent, backLabel)}
           onClick={noop}
         />

--- a/src/hooks/api/use-fetch-wrapper.ts
+++ b/src/hooks/api/use-fetch-wrapper.ts
@@ -39,7 +39,12 @@ export function useFetchWrapper(prependApiUrl?: string) {
   useEffect(() => {
     return () => {
       // always let an outgoing refresh finish before aborting
-      refreshPromiseLock?.then(() => abortController.abort());
+      if (refreshPromiseLock) {
+        refreshPromiseLock.then(() => abortController.abort());
+        refreshPromiseLock = undefined;
+      } else {
+        abortController.abort();
+      }
     };
   }, []);
 

--- a/src/hooks/use-deck-editor.ts
+++ b/src/hooks/use-deck-editor.ts
@@ -68,11 +68,8 @@ export const useDeckEditor = (deck: Deck): DeckEditorReturn => {
       const updatedCards = Object.values(state.updatedCards).filter(filterBlankCards);
       const deletedCards = Object.values(state.deletedCards);
 
-      // alone to prevent race condition on backend since updating cards mutates a deck as well
-      // this resolves the issue where updating both metadata and cards can cause the metadata to not save
-      await decksClient.updateDeckById(state.currentDeck);
-
       const cardPromises = [
+        decksClient.updateDeckById(state.currentDeck),
         ...[addedCards.length > 0 ? cardsClient.addCards(addedCards, deckId) : []],
         ...[updatedCards.length > 0 ? cardsClient.updateCards(updatedCards) : []],
         ...[deletedCards.length > 0 ? cardsClient.deleteCards(deletedCards) : []],

--- a/src/pages/edit-deck-page/deck-editor/deck-editor.test.tsx
+++ b/src/pages/edit-deck-page/deck-editor/deck-editor.test.tsx
@@ -138,12 +138,17 @@ describe('DeckEditor', () => {
         onGoBackClick={noop}
       />
     );
-    userEvent.click(screen.getByText('create'));
 
+    // add a new card to trigger changes (which activates create button)
+    userEvent.click(screen.getByText('new card'));
+    expect(screen.queryByPlaceholderText('add term')).toBeInTheDocument();
+    expect(screen.queryByPlaceholderText('add definition')).toBeInTheDocument();
+
+    userEvent.click(screen.getByText('create'));
     expect(mockOnCreateDeckClick).toBeCalled();
   });
 
-  it('should call disable create button when title is empty', () => {
+  it('should disable create button when title is empty', () => {
     const mockOnCreateDeckClick = jest.fn();
     renderWithTestRoots(
       <DeckEditor
@@ -154,8 +159,13 @@ describe('DeckEditor', () => {
         onGoBackClick={noop}
       />
     );
-    userEvent.click(screen.getByText('create'));
 
+    // even adding a new card will not enable button without a title and description
+    userEvent.click(screen.getByText('new card'));
+    expect(screen.queryByPlaceholderText('add term')).toBeInTheDocument();
+    expect(screen.queryByPlaceholderText('add definition')).toBeInTheDocument();
+
+    userEvent.click(screen.getByText('create'));
     expect(mockOnCreateDeckClick).not.toBeCalled();
   });
 

--- a/src/pages/edit-deck-page/deck-editor/deck-editor.tsx
+++ b/src/pages/edit-deck-page/deck-editor/deck-editor.tsx
@@ -45,7 +45,8 @@ export const DeckEditor = ({
   const [isPromptEnabled, setIsPromptEnabled] = useState(true);
   const [activeCardKey, setActiveCardKey] = useState('');
 
-  const isSaveButtonDisabled = isSaving || !deck.metaData.title || !deck.metaData.desc;
+  const hasMetadataFilled = deck.metaData.title && deck.metaData.desc;
+  const isSaveButtonDisabled = isSaving || !hasUnsavedChanges || !hasMetadataFilled;
 
   usePrompt('Changes you made may not be saved.', isPromptEnabled && hasUnsavedChanges); // prevent navigation if there are unsaved changes
 

--- a/src/pages/study-page/study-results-page/study-results-page.scss
+++ b/src/pages/study-page/study-results-page/study-results-page.scss
@@ -13,6 +13,7 @@
 
   .study-results-page-header {
     @include flex-center;
+    gap: 64px;
     margin: 20px;
     width: 100%;
 
@@ -20,12 +21,20 @@
       @include flex-center;
       flex-basis: 0;
       flex-grow: 1;
+      flex-shrink: 0;
+
+      @media screen and (max-width: $giant-screen) {
+        flex-wrap: wrap;
+      }
     }
 
     h1 {
       text-align: center;
-      min-width: fit-content;
-      margin: 20px;
+      flex: 3;
+
+      @media screen and (max-width: $giant-screen) {
+        flex: 8;
+      }
     }
 
     .study-results-page-nav-buttons {
@@ -44,10 +53,15 @@
           }
         }
       }
+
+      @media screen and (min-width: $giant-screen) {
+        align-self: flex-start;
+      }
     }
 
     @media screen and (max-width: $large-screen) {
       flex-direction: column;
+      gap: 8px;
 
       .study-results-page-nav-buttons {
         justify-content: center;

--- a/src/pages/view-deck-page/view-deck-page.scss
+++ b/src/pages/view-deck-page/view-deck-page.scss
@@ -13,6 +13,7 @@ $flashcard-index-container-width: 45px;
     grid-template-columns: auto min-content;
     grid-template-rows: min-content auto;
     column-gap: 16px;
+    overflow-wrap: anywhere;
 
     .action-button-group {
       display: flex;

--- a/src/pages/view-deck-page/view-deck-page.scss
+++ b/src/pages/view-deck-page/view-deck-page.scss
@@ -12,7 +12,7 @@ $flashcard-index-container-width: 45px;
     grid-auto-flow: row;
     grid-template-columns: auto min-content;
     grid-template-rows: min-content auto;
-    column-gap: 8px;
+    column-gap: 16px;
 
     .action-button-group {
       display: flex;


### PR DESCRIPTION
### fetch wrapper
- fixes a bug introduced last PR where it wouldn't abort fetches on unmount if there hadn't been a refresh before
- i still can't reproduce the logging out bug, lmk if it occurs again and i'll look into it some more

### text overflow
- introduce `grid-center` which performs safe centering when the inner container overflows the parent
- introduce `multiline-ellipsis-overflow` which allows containers to describe the max lines before overflowing
- improve text overflow on these areas:
  - flashcard decks
  - view flashcard
  - study page popup, study page (+ lesson card), and results page

### deck editor
- disable save button when there are no changes
- fix race condition caused by two requests modifying a deck
  - can observe that sometimes when editing title+desc and adding cards, only the cards are updated

---

https://user-images.githubusercontent.com/29434693/197456560-6f5ff842-f15c-41da-abee-a60b36da5d90.mp4

https://user-images.githubusercontent.com/29434693/197456565-bb5e1d33-f64c-407f-94bd-ac1716134068.mp4


