### PR TITLE
fix: keep lesson card outcomes on skip or replay

### DIFF
--- a/src/components/deck-cover/deck-cover.test.tsx
+++ b/src/components/deck-cover/deck-cover.test.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { noop } from '@/helpers/func';
+import { Deck } from '@/models/deck';
+import { getTestFoxCard } from '@/models/mock/card.mock';
 import { testEnglishDeck } from '@/models/mock/deck.mock';
 import { DeckCover } from './deck-cover';
 
@@ -29,20 +31,62 @@ describe('DeckCover', () => {
     expect(mockOnClick).toBeCalled();
   });
 
-  it('should fire all click listeners', () => {
-    const mockAllOnClick = jest.fn();
+  it('should fire onStudyClick only when there are cards', () => {
+    const mockOnStudyClick = jest.fn();
+    const { rerender } = render(
+      <DeckCover
+        deck={TEST_DECK}
+        onClick={noop}
+        onViewClick={noop}
+        onStudyClick={mockOnStudyClick}
+      />
+    );
+
+    // study is disabled with no cards
+    userEvent.click(screen.getByText('study'));
+    expect(mockOnStudyClick).toBeCalledTimes(0);
+
+    // rerender using deck with cards
+    const testCards = [...Array(5)].map(() => getTestFoxCard());
+    const deckWithCards: Deck = {
+      metaData: { ...TEST_DECK.metaData, cardIds: [...Array(testCards.length)] },
+      cards: testCards,
+    };
+    rerender(
+      <DeckCover
+        deck={deckWithCards}
+        onClick={noop}
+        onViewClick={noop}
+        onStudyClick={mockOnStudyClick}
+      />
+    );
+
+    // study button should be enabled with cards
+    userEvent.click(screen.getByText('study'));
+    expect(mockOnStudyClick).toBeCalledTimes(1);
+  });
+
+  it('should fire all default click listeners', () => {
+    const mockOnClick = jest.fn();
+    const mockOnViewClick = jest.fn();
+    const mockOnStudyClick = jest.fn();
     render(
       <DeckCover
         deck={TEST_DECK}
-        onClick={mockAllOnClick}
-        onStudyClick={mockAllOnClick}
-        onViewClick={mockAllOnClick}
+        onClick={mockOnClick}
+        onViewClick={mockOnViewClick}
+        onStudyClick={mockOnStudyClick}
       />
     );
 
     userEvent.click(screen.queryAllByText(TEST_DECK.metaData.title)[0]);
+    expect(mockOnClick).toBeCalledTimes(1);
+
     userEvent.click(screen.getByText('view'));
+    expect(mockOnViewClick).toBeCalledTimes(1);
+
+    // study is disabled with no cards
     userEvent.click(screen.getByText('study'));
-    expect(mockAllOnClick).toBeCalledTimes(3);
+    expect(mockOnStudyClick).toBeCalledTimes(0);
   });
 });

--- a/src/components/deck-cover/deck-cover.tsx
+++ b/src/components/deck-cover/deck-cover.tsx
@@ -49,6 +49,7 @@ export const DeckCover = ({
   }
 
   function getCoverBack() {
+    const numCards = deck.metaData.cardIds.length;
     const studiedPercent = deck.metaData.studiedPercent;
     const progressBarPercent = studiedPercent === 0 ? 0 : Math.max(studiedPercent, 15); // looks ugly at <15
     return (
@@ -66,7 +67,7 @@ export const DeckCover = ({
           <Button bubbleOnClickEvent={false} onClick={onViewClick}>
             view
           </Button>
-          <Button bubbleOnClickEvent={false} onClick={onStudyClick}>
+          <Button bubbleOnClickEvent={false} disabled={numCards == 0} onClick={onStudyClick}>
             study
           </Button>
         </div>

--- a/src/components/study-flashcard/study-flashcard.tsx
+++ b/src/components/study-flashcard/study-flashcard.tsx
@@ -5,25 +5,27 @@ import { noop } from '@/helpers/func';
 import './study-flashcard.scss';
 
 interface StudyFlashcardProps {
+  id: string;
   frontContent: ReactNode;
   backContent: ReactNode;
   activeSide: 'front' | 'back';
   variant: 'light' | 'dark';
-  cardFaceClass?: string;
+  frontClassName?: string;
+  backClassName?: string;
   frontLabel?: string;
   backLabel?: string;
-  id: string;
 }
 
 export const StudyFlashcard = ({
+  id,
   frontContent,
-  frontLabel = '',
-  cardFaceClass = '',
   backContent,
-  backLabel = '',
   activeSide,
   variant,
-  id,
+  frontClassName = '',
+  backClassName = '',
+  frontLabel = '',
+  backLabel = '',
 }: StudyFlashcardProps) => {
   // TODO: Allow card to be flippable, but reset on the content changes
   return (
@@ -38,18 +40,19 @@ export const StudyFlashcard = ({
         <FlipTile
           className="study-card"
           isFlipped={activeSide !== 'front'}
-          front={getCardFace(frontContent, frontLabel)}
+          front={getCardFace(frontContent, frontLabel, frontClassName)}
           frontClassName={'study-card-front dark'}
-          back={getCardFace(backContent, backLabel)}
+          back={getCardFace(backContent, backLabel, backClassName)}
           onClick={noop}
         />
       </motion.div>
     </AnimatePresence>
   );
 
-  function getCardFace(content: ReactNode, label: string) {
+  function getCardFace(content: ReactNode, label: string, extraClasses?: string) {
+    const extras = extraClasses ?? '';
     return (
-      <div className={`c-study-flashcard-content  ${variant} ${cardFaceClass}`}>
+      <div className={`c-study-flashcard-content ${variant} ${extras}`}>
         <label className="c-study-flashcard-side-label">{label}</label>
         <div className="c-study-flashcard-text">{content}</div>
       </div>

--- a/src/hooks/use-play-lesson.ts
+++ b/src/hooks/use-play-lesson.ts
@@ -147,8 +147,6 @@ export function usePlayLesson({ deck, studyConfig }: UsePlayLessonSettings) {
       throw new Error('card audio could not be found');
     }
 
-    console.log('currently playing', currentCard);
-
     // active card key must be changed
     setActiveCard(currentCard.key);
 
@@ -192,7 +190,6 @@ export function usePlayLesson({ deck, studyConfig }: UsePlayLessonSettings) {
 
     // queue and play next card (if one exists)
     const next = nextCard(updatedCard, upcomingCards, completedCards);
-    console.log('card updated, now', updatedCard);
     next && playCard(next.currentCard, next.upcomingCards, next.completedCards);
   }
 

--- a/src/hooks/use-play-lesson.ts
+++ b/src/hooks/use-play-lesson.ts
@@ -122,11 +122,10 @@ export function usePlayLesson({ deck, studyConfig }: UsePlayLessonSettings) {
       stopCapturingSpeech();
     }
 
-    // TODO: although we change it back to unseen, can we have a record (map) of if it was previously correct?
-    // undo the last result
+    // previous card may already have a result, and that's fine bc it'll be overridden if user gets it incorrect/correct again
+    // if it becomes problematic (styling), we can override back to unseen and keep a record of prior answers for the card id
     const next = previousCard(currentCard, upcomingCards, completedCards);
-    const updatedCard: LessonCard = { ...next.currentCard, outcome: 'unseen' };
-    setCurrentCard(updatedCard);
+    setCurrentCard(next.currentCard);
 
     if (!isPaused) {
       playCard(next.currentCard, next.upcomingCards, next.completedCards);
@@ -147,6 +146,8 @@ export function usePlayLesson({ deck, studyConfig }: UsePlayLessonSettings) {
     if (!currentCard.front.audio || !currentCard.back.audio) {
       throw new Error('card audio could not be found');
     }
+
+    console.log('currently playing', currentCard);
 
     // active card key must be changed
     setActiveCard(currentCard.key);
@@ -191,6 +192,7 @@ export function usePlayLesson({ deck, studyConfig }: UsePlayLessonSettings) {
 
     // queue and play next card (if one exists)
     const next = nextCard(updatedCard, upcomingCards, completedCards);
+    console.log('card updated, now', updatedCard);
     next && playCard(next.currentCard, next.upcomingCards, next.completedCards);
   }
 
@@ -225,6 +227,7 @@ export function usePlayLesson({ deck, studyConfig }: UsePlayLessonSettings) {
     if (completedCards.length === 0) {
       return { currentCard, upcomingCards, completedCards };
     }
+
     const newUpcomingCards = [currentCard, ...upcomingCards];
     const newCurrentCard = completedCards[0];
     const newCompletedCards = completedCards.slice(1);

--- a/src/pages/_shared/study-config-popup/study-config-popup.scss
+++ b/src/pages/_shared/study-config-popup/study-config-popup.scss
@@ -67,6 +67,7 @@
 
       .max-cards-textbox {
         width: 56px;
+        text-align: center;
 
         input {
           font-size: 18px;
@@ -87,7 +88,7 @@
     .max-cards-error {
       font-size: 13px;
       color: $light-red;
-      padding-top: 0.33rem;
+      padding-top: 0.5rem;
     }
   }
 

--- a/src/pages/_shared/study-config-popup/study-config-popup.tsx
+++ b/src/pages/_shared/study-config-popup/study-config-popup.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useLayoutEffect, useState } from 'react';
 import { createSearchParams, useNavigate } from 'react-router-dom';
 import { AnimatePresence } from 'framer-motion';
 import { FadeReveal } from '@/animations/fade-reveal';
@@ -54,6 +54,12 @@ export const StudyConfigPopup = ({
   const [maxCardsError, setMaxCardsError] = useState<string>();
 
   const navigate = useNavigate();
+
+  useLayoutEffect(() => {
+    if (numCards == 0) {
+      setMaxCardsError('Cannot study a deck with no cards.');
+    }
+  }, [numCards]);
 
   return (
     <PopupModal
@@ -145,6 +151,11 @@ export const StudyConfigPopup = ({
       return;
     }
 
+    if (numCards == 0) {
+      setMaxCardsError('Cannot study a deck with no cards.');
+      return;
+    }
+
     const deckId = deck.metaData.id;
     const params: Partial<Record<keyof StudyConfiguration, string>> = {
       studyType: studyType,
@@ -159,6 +170,11 @@ export const StudyConfigPopup = ({
   }
 
   function handlePopupClose() {
+    if (numCards == 0) {
+      navigate(`${paths.deck}/${deck.metaData.id}`);
+      return;
+    }
+
     onClose({
       studyType: studyType,
       order: orderOption,

--- a/src/pages/landing-page/landing-page.scss
+++ b/src/pages/landing-page/landing-page.scss
@@ -26,7 +26,7 @@
     left: 50%;
     transform: translate(-50%, -50%);
 
-    @media screen and (max-height: $medium-screen) {
+    @media screen and (max-height: $medium-screen), (min-width: $giant-screen) {
       left: unset;
       right: 0;
     }

--- a/src/pages/study-page/study-lesson-page/study-lesson-page.tsx
+++ b/src/pages/study-page/study-lesson-page/study-lesson-page.tsx
@@ -127,12 +127,12 @@ export const StudyLessonPage = ({ deck, studyConfig, onLessonComplete }: StudyPa
       <StudyFlashcard
         id={currentCard.key}
         variant="light"
-        cardFaceClass={cardFaceClass}
+        activeSide={activeCardSide}
+        frontLabel="term"
+        backLabel="definition"
         frontContent={currentCard.front.text}
         backContent={currentCard.back.text}
-        backLabel="definition"
-        frontLabel="term"
-        activeSide={activeCardSide}
+        backClassName={cardFaceClass} /* only back of card should show outcome class */
       />
     );
   }

--- a/src/pages/view-deck-pages/view-personal-deck-page/view-personal-deck-page.tsx
+++ b/src/pages/view-deck-pages/view-personal-deck-page/view-personal-deck-page.tsx
@@ -18,6 +18,8 @@ interface ViewPersonalDeckPageProps {
 
 export const ViewPersonalDeckPage = ({ deck }: ViewPersonalDeckPageProps) => {
   const navigate = useNavigate();
+
+  const numCards = deck.metaData.cardIds.length;
   const percentStudied = deck.metaData.studiedPercent;
   const progressBarPercent = percentStudied === 0 ? 0 : Math.max(5, percentStudied);
   const tags = getDeckBubbleTags(deck);
@@ -32,7 +34,11 @@ export const ViewPersonalDeckPage = ({ deck }: ViewPersonalDeckPageProps) => {
         </div>
 
         <div className="action-button-group">
-          <Button onClick={() => navigate(`${paths.study}/${deck.metaData.id}`)} size="medium">
+          <Button
+            onClick={() => navigate(`${paths.study}/${deck.metaData.id}`)}
+            disabled={numCards == 0}
+            size="medium"
+          >
             study
           </Button>
           <Button onClick={() => navigate(`${paths.editDeck}/${deck.metaData.id}`)} size="medium">


### PR DESCRIPTION
#### lesson card
- skipping or replaying cards no longer overwrite the previous outcome
- this works because now, we only apply the outcome style on the back of the card

#### study
- disable study buttons with there are no cards 
- prevent access to lesson if manually navigating to study page on a deck with no cards
