### PR TITLE
fix: improve dropdown options styling

### DIFF
--- a/src/components/drop-down-options/drop-down-options.scss
+++ b/src/components/drop-down-options/drop-down-options.scss
@@ -15,8 +15,15 @@
     min-width: fit-content;
   }
 
-  .ellipsis-overflow {
+  &.ellipsis-overflow {
     @include ellipsis-overflow;
+  }
+
+  .c-options-grid {
+    display: grid;
+    grid-auto-flow: row;
+    grid-auto-rows: 1fr;
+    width: 100%;
   }
 
   .c-drop-down-option {
@@ -29,6 +36,10 @@
     padding: 5px;
     border-radius: 0;
     text-align: left;
+
+    &.ellipsis-overflow {
+      @include ellipsis-overflow;
+    }
 
     &:first-child {
       border-top-left-radius: $standard-radius;

--- a/src/components/drop-down-options/drop-down-options.tsx
+++ b/src/components/drop-down-options/drop-down-options.tsx
@@ -34,12 +34,12 @@ export const DropDownOptions = <I extends string, V extends ReactNode>({
   options,
   onOptionSelect,
 }: DropDownOptionsProps<I, V>) => {
-  const optionsClass = 'c-drop-down-options' + (ellipsisOverflow ? ' ellipsis-overflow' : '');
+  const ellipsisClass = ellipsisOverflow ? ' ellipsis-overflow' : '';
   return (
     <AnimatePresence>
       {show && options !== undefined && (
-        <Fade fadeIn={false} className={`${optionsClass} ${className}`}>
-          {options.map(getOption)}
+        <Fade fadeIn={false} className={`c-drop-down-options ${ellipsisClass} ${className}`}>
+          <div className="c-options-grid">{options.map(getOption)}</div>
         </Fade>
       )}
     </AnimatePresence>
@@ -51,7 +51,7 @@ export const DropDownOptions = <I extends string, V extends ReactNode>({
       return (
         <Button
           key={option.id}
-          className={className}
+          className={`c-drop-down-option ${ellipsisClass}`}
           variant="invisible"
           onClick={() => onOptionSelect(option)}
         >


### PR DESCRIPTION
## rebase on main before merging

### summary of changes
- fix bug with ellipsis overflow selector on parent (options container)
- add ellipsis overflow to child (single option) as well
- wrap all options in a grid component that evenly distributes height

---

**(search box)**
![image](https://user-images.githubusercontent.com/29434693/201438928-e1fa8600-1458-48e8-aa85-38529d35625c.png)

**(card options)**
![image](https://user-images.githubusercontent.com/29434693/201438905-11bbb2e2-bb62-49c0-8327-7f38d4d69f3b.png)

