### PR TITLE
fix: await cards promise before passing as payload

### DIFF
--- a/src/helpers/types.ts
+++ b/src/helpers/types.ts
@@ -1,0 +1,16 @@
+/**
+ * ExtractIfArray<Promise<boolean>[]>  => Promise<boolean>
+ * ExtractIfArray<number[]>            => number
+ */
+export type ExtractIfArray<T> = T extends (infer U)[] ? U : T;
+
+/**
+ * Coerces a type to not be a promise (by yielding `never`).
+ *
+ * NotPromise<Promise<boolean>>    => never
+ * NotPromise<Promise<boolean>[]>  => never
+ * NotPromise<boolean>             => boolean
+ */
+export type NotPromise<T> = ExtractIfArray<T> extends Promise<unknown>
+  ? { TypeError: `type cannot be a promise, did you forget to await it?` }
+  : T;

--- a/src/hooks/api/use-cards-client.ts
+++ b/src/hooks/api/use-cards-client.ts
@@ -80,7 +80,7 @@ export function useCardsClient() {
 
   // POST: /Cards
   async function addCards(cards: DraftCard[] | Card[], deckId: number): Promise<NewCardsResponse> {
-    const cardsToAdd = Promise.all(cards.map((card) => cardToJson(card, deckId)));
+    const cardsToAdd = await Promise.all(cards.map((card) => cardToJson(card, deckId)));
     const response = await fetchWrapper.post('/cards', cardsToAdd);
     return response;
   }

--- a/src/hooks/api/use-fetch-wrapper.ts
+++ b/src/hooks/api/use-fetch-wrapper.ts
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { useSetRecoilState } from 'recoil';
 import { ECHOSTUDY_API_URL } from '@/helpers/api';
 import { deferredPromise } from '@/helpers/promise';
+import { NotPromise } from '@/helpers/types';
 import { isDefined, objectSchemaSimple } from '@/helpers/validator';
 import { useLocalStorage } from '@/hooks/use-local-storage';
 import { paths } from '@/routing/paths';
@@ -56,7 +57,11 @@ export function useFetchWrapper(prependApiUrl?: string) {
   };
 
   function request(method: string) {
-    return async function (url: string, body?: object, numRetries = 1) {
+    return async function <TBody extends object>(
+      url: string,
+      body?: NotPromise<TBody>,
+      numRetries = 1
+    ) {
       try {
         return await _retryFetch(url, method, body, numRetries);
       } catch (error) {


### PR DESCRIPTION
## rebase on main before merging

- fixes cards not being added when a new deck is created
- enforce fetch wrapper to only allow non-promises as payload to avoid future oopsies