### PR TITLE
feat: add card limit and remove assertions

### DIFF
--- a/src/hooks/api/use-cards-client.ts
+++ b/src/hooks/api/use-cards-client.ts
@@ -69,6 +69,7 @@ export function useCardsClient() {
     const cardsData = await fetchWrapper.get(`/public/cards?deckId=${deckId}`);
     return cardsData.map(JsonToCard);
   }
+
   //////////////////////
   /// adds & updates ///
   //////////////////////
@@ -92,7 +93,7 @@ export function useCardsClient() {
 
   // POST: /Cards/Update
   async function updateCards(cards: DraftCard[] | Card[]): Promise<NewCardsResponse> {
-    cards.forEach((card) => assertIdIsNumber(card.id));
+    // cards.forEach((card) => assertIdIsNumber(card.id));
     const cardsToUpdate = await Promise.all(cards.map((card) => cardToJson(card)));
     const response = await fetchWrapper.post(`/cards/update`, cardsToUpdate);
     return response;
@@ -109,13 +110,13 @@ export function useCardsClient() {
 
   // POST: /Cards/Delete
   async function deleteCard(card: Card): Promise<void> {
-    assertIdIsNumber(card.id);
+    // assertIdIsNumber(card.id);
     return deleteCards([card]);
   }
 
   // POST: /Cards/Delete
   async function deleteCards(cards: Card[]): Promise<void> {
-    cards.forEach((card) => assertIdIsNumber(card.id));
+    // cards.forEach((card) => assertIdIsNumber(card.id));
 
     const cardsToDelete = cards.map((card) => card.id).filter(isDefined);
     return fetchWrapper.post(`/cards/delete`, cardsToDelete);

--- a/src/pages/edit-deck-page/deck-editor/deck-editor.tsx
+++ b/src/pages/edit-deck-page/deck-editor/deck-editor.tsx
@@ -166,6 +166,11 @@ export const DeckEditor = ({
   }
 
   function handleSubmitClick() {
+    if (deck.cards.length > 500) {
+      alert('echoStudy does not currently support decks with over 500 cards.');
+      return;
+    }
+
     if (isNewDeck) {
       setIsPromptEnabled(false);
       onCreateDeckClick(deck); // Todo: await and handle errors


### PR DESCRIPTION
- card limit of 500
- remove assertions, it breaks deletions that have not been serialized yet
  - better let it fail on the server side (if it does), than for us to fail it when it really doesn't break anything 